### PR TITLE
Cppcompiletest

### DIFF
--- a/codegen/mabl2cpp/src/main/resources/org/intocps/maestro/codegen/mabl2cpp/readme.md
+++ b/codegen/mabl2cpp/src/main/resources/org/intocps/maestro/codegen/mabl2cpp/readme.md
@@ -1,10 +1,13 @@
 # Compilation
 
 ## Windows
-
 Install i.e.:
+1. msys with mingw64 (https://www.msys2.org/)
+2. Follow the guide at https://www.msys2.org/
+3. Add C:\msys64\mingw64\bin
+4. Add C:\msys64\usr\bin
+5. Run pacman -S mingw-w64-x86_64-cmake in the MSYS terminal
 
-- msys with mingw64 (https://www.msys2.org/)
 
 ## Linux (ubuntu)
 

--- a/codegen/mabl2cpp/src/main/resources/org/intocps/maestro/codegen/mabl2cpp/readme.md
+++ b/codegen/mabl2cpp/src/main/resources/org/intocps/maestro/codegen/mabl2cpp/readme.md
@@ -4,11 +4,7 @@
 
 Install i.e.:
 
-- msys (https://www.msys2.org/)
-
-Packages:
-
-- libzip
+- msys with mingw64 (https://www.msys2.org/)
 
 ## Linux (ubuntu)
 

--- a/maestro/src/test/java/org/intocps/maestro/util/CMakeUtil.java
+++ b/maestro/src/test/java/org/intocps/maestro/util/CMakeUtil.java
@@ -150,8 +150,9 @@ public class CMakeUtil {
         if (autoNinja && hasNinja()) {
             cmds.add("-GNinja");
         } else if (isWindows()) {
-            cmds.add("-GMSYS Makefiles");
+            //            cmds.add("-GMSYS Makefiles");
             //            cmds.add("\"MSYS Makefiles\"");
+            cmds.add("-GMinGW Makefiles");
         }
 
         if (install != null) {

--- a/maestro/src/test/java/org/intocps/maestro/util/CMakeUtil.java
+++ b/maestro/src/test/java/org/intocps/maestro/util/CMakeUtil.java
@@ -150,9 +150,7 @@ public class CMakeUtil {
         if (autoNinja && hasNinja()) {
             cmds.add("-GNinja");
         } else if (isWindows()) {
-            //            cmds.add("-GMSYS Makefiles");
-            //            cmds.add("\"MSYS Makefiles\"");
-            cmds.add("-GMinGW Makefiles");
+            cmds.add("-GMSYS Makefiles");
         }
 
         if (install != null) {
@@ -172,8 +170,6 @@ public class CMakeUtil {
 
 
         pb.directory(source);
-
-        System.out.println("Running CMAKE command: " + String.join(" ", cmds));
 
         return runProcess(pb, verbose);
 
@@ -197,7 +193,6 @@ public class CMakeUtil {
         for (String string : goal) {
             pb.command().add(string);
         }
-        //pb.directory(root);
 
         return runProcess(pb, verbose);
 

--- a/maestro/src/test/java/org/intocps/maestro/util/CMakeUtil.java
+++ b/maestro/src/test/java/org/intocps/maestro/util/CMakeUtil.java
@@ -172,6 +172,8 @@ public class CMakeUtil {
 
         pb.directory(source);
 
+        System.out.println("Running CMAKE command: " + String.join(" ", cmds));
+
         return runProcess(pb, verbose);
 
     }

--- a/readme.md
+++ b/readme.md
@@ -24,8 +24,18 @@ terminal and reimporting in the maven control panel of IntelliJ.
 
 ### CPP environment installation guide
 
-1. Follow the guide at https://www.msys2.org/
-2. Add C:\msys64\mingw64\bin
+#### Windows
+1. Install msys with mingw64 (https://www.msys2.org/)
+2. Follow the guide at https://www.msys2.org/
+3. Add C:\msys64\mingw64\bin to Path
+4. Add C:\msys64\usr\bin to Path
+5. Run pacman -S mingw-w64-x86_64-cmake in the MSYS terminal
+
+#### Linux (ubuntu)
+
+```bash
+apt install git libzip-dev build-essential cmake
+```
 
 ## Release the tool
 

--- a/readme.md
+++ b/readme.md
@@ -5,10 +5,10 @@
 
 Maestro 2 is the next version of the Maestro Co-simulation Orchestration Engine.
 
-#### Development Environment
+## Development Environment
 
 You need Java 11 and maven 3.6 to build the project. For the external / integration tests it also needs a functioning
-cpp environment with CMake (on windows MSYS)
+cpp environment with CMake (on windows MSYS). See guide below under CPP environment installation guide
 
 The project can be built from CLI using the maven command:.
 
@@ -21,6 +21,11 @@ Scala code in this project. As long as you keep this in mind, you are welcome to
 
 If IntelliJ fails to build the project after import, then it might be resolved by executing `mvn install` in the
 terminal and reimporting in the maven control panel of IntelliJ.
+
+### CPP environment installation guide
+
+1. Follow the guide at https://www.msys2.org/
+2. Add C:\msys64\mingw64\bin
 
 ## Release the tool
 


### PR DESCRIPTION
FullSpecCppTest and CLI export cpp (external test) now works with Windows given the right environment variables.