### PR TITLE
Kel/338 error handling broken

### DIFF
--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/ComponentVariableFmi2Api.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/ComponentVariableFmi2Api.java
@@ -1333,7 +1333,7 @@ public class ComponentVariableFmi2Api extends VariableFmi2Api<Fmi2Builder.NamedV
                         .error(s, method.substring(0, 1).toUpperCase() + method.substring(1) + " failed on '%s' with status: " + status, instance);
             }
 
-            thenScope.add(new AErrorStm(newAStringLiteralExp("Failed to load instance " + instance.getName())));
+            thenScope.add(new AErrorStm(newAStringLiteralExp("Failed to '" + method + "' on '" + instance.getName() + "'")));
             thenScope.leave();
         }
 

--- a/maestro/src/test/java/org/intocps/maestro/BuilderTest.java
+++ b/maestro/src/test/java/org/intocps/maestro/BuilderTest.java
@@ -74,6 +74,13 @@ public class BuilderTest {
         DynamicActiveBuilderScope dynamicScope = builder.getDynamicScope();
 
         tank.setupExperiment(0d, 10d, null);
+        controller.setupExperiment(0d, 10d, null);
+
+        controller.enterInitializationMode();
+        tank.enterInitializationMode();
+
+        controller.exitInitializationMode();
+        tank.exitInitializationMode();
  /*
         IMablScope scope1 = dynamicScope.getActiveScope();
         for (int i = 0; i < 4; i++) {
@@ -93,11 +100,13 @@ public class BuilderTest {
 
         controller.getAndShare("valve");
         controller.getAndShare();
+
         tank.setLinked();
-        // tank.set();
+        //        tank.set();
         Fmi2Builder.DoubleVariable<PStm> var = dynamicScope.store(123.123);
+        Fmi2Builder.DoubleVariable<PStm> current_time_point = dynamicScope.store(0.0);
         Fmi2Builder.DoubleVariable<PStm> step = dynamicScope.store(0.1);
-        tank.step(var, step);
+        tank.step(current_time_point, step);
         //Fmi2Builder.StateVariable<PStm> s = tank.getState();
 
         logger.warn("Something is wrong %f -- %f. Fmu %s, Instance %s", 1.3, step, controllerFMU, controller);

--- a/plugins/fixedstep/src/main/java/org/intocps/maestro/plugin/JacobianFixedStep.java
+++ b/plugins/fixedstep/src/main/java/org/intocps/maestro/plugin/JacobianFixedStep.java
@@ -130,12 +130,11 @@ public class JacobianFixedStep {
                                             newABoolLiteralExp(false)),
 
                                     newExpressionStm(newACallExp(newAIdentifierExp("logger"), newAIdentifier("log"),
-                                            Arrays.asList(newAIntLiteralExp(4), newAStringLiteralExp("doStep failed for %d - status code "),
+                                            Arrays.asList(newAIntLiteralExp(4),
+                                                    newAStringLiteralExp("doStep failed with status %d for component " + "index %d"),
                                                     newAArrayIndexExp(newAIdentifierExp(fixedStepStatus),
-                                                            Arrays.asList(newAIdentifierExp((LexIdentifier) compIndexVar.clone()))))))
-
-
-                                    , new AErrorStm())), null),
+                                                            Arrays.asList(newAIdentifierExp((LexIdentifier) compIndexVar.clone()))),
+                                                    newAIdentifierExp((LexIdentifier) compIndexVar.clone())))))), null),
 
 
                             newAAssignmentStm(newAIdentifierStateDesignator((LexIdentifier) compIndexVar.clone()),
@@ -186,13 +185,15 @@ public class JacobianFixedStep {
                                                                                     Arrays.asList(newAIdentifierExp((LexIdentifier) compIndexVar.clone()))),
                                                                             newAIntLiteralExp(FMI_FATAL)))),
 
-                                                                    newExpressionStm(newACallExp(newAIdentifierExp("logger"), newAIdentifier("log"),
-                                                                            Arrays.asList(newAIntLiteralExp(4),
-                                                                                    newAStringLiteralExp("doStep failed for %d - status code "),
-                                                                                    newAArrayIndexExp(newAIdentifierExp(fixedStepStatus),
-                                                                                            Arrays.asList(newAIdentifierExp(
-                                                                                                    (LexIdentifier) compIndexVar.clone())))))),
-                                                                    null)), newIf(newEqual(newAArrayIndexExp(newAIdentifierExp(fixedStepStatus),
+                                                                    newABlockStm(newExpressionStm(
+                                                                                    newACallExp(newAIdentifierExp("logger"), newAIdentifier("log"),
+                                                                                            Arrays.asList(newAIntLiteralExp(4), newAStringLiteralExp(
+                                                                                                            "doStep failed for %d - status code "),
+                                                                                                    newAArrayIndexExp(newAIdentifierExp(fixedStepStatus),
+                                                                                                            Arrays.asList(newAIdentifierExp(
+                                                                                                                    (LexIdentifier) compIndexVar.clone())))))),
+                                                                            new AErrorStm(new AStringLiteralExp("do step failed"))), null)),
+                                                    newIf(newEqual(newAArrayIndexExp(newAIdentifierExp(fixedStepStatus),
                                                                     Arrays.asList(newAIdentifierExp((LexIdentifier) compIndexVar.clone()))),
                                                             newAIntLiteralExp(FMI_DISCARD)), newABlockStm(newExpressionStm(
                                                                     simLog(LogUtil.SimLogLevel.DEBUG, "Instance discarding %d",
@@ -205,7 +206,7 @@ public class JacobianFixedStep {
 
                                                     , newAAssignmentStm(
                                                             newAIdentifierStateDesignator(newAIdentifier(IMaestroPlugin.GLOBAL_EXECUTION_CONTINUE)),
-                                                            newABoolLiteralExp(false)), new AErrorStm())), null),
+                                                            newABoolLiteralExp(false)))), null),
 
 
                                     newAAssignmentStm(newAIdentifierStateDesignator((LexIdentifier) compIndexVar.clone()),
@@ -231,18 +232,16 @@ public class JacobianFixedStep {
 
                                             }, newAIdentifierExp(fixedStepStatus), newAIntLiteralExp(componentNames.size()), (index, comp) -> {
 
-                                                return Arrays.asList(newIf(newEqual(newAArrayIndexExp(newAIdentifierExp(fixedStepStatus),
-                                                                Arrays.asList(newAIdentifierExp((LexIdentifier) compIndexVar.clone()))),
+                                                return Arrays.asList(newIf(newEqual(
+                                                        newAArrayIndexExp(newAIdentifierExp(fixedStepStatus), Arrays.asList(index.clone())),
                                                         newAIntLiteralExp(FMI_DISCARD)), newABlockStm(Arrays.asList(
 
                                                         newAAssignmentStm(newAIdentifierStateDesignator(newAIdentifier(fix_recovering)),
                                                                 newABoolLiteralExp(true)),
 
                                                         newAAssignmentStm(newAArayStateDesignator(
-                                                                        newAIdentifierStateDesignator(newAIdentifier(fixedStepStatus)),
-                                                                        newAIdentifierExp((LexIdentifier) compIndexVar.clone())),
-                                                                call(arrayGet(componentsIdentifier,
-                                                                                newAIdentifierExp((LexIdentifier) compIndexVar.clone())), "getRealStatus",
+                                                                        newAIdentifierStateDesignator(newAIdentifier(fixedStepStatus)), index.clone()),
+                                                                call(arrayGet(componentsIdentifier, index.clone()), "getRealStatus",
                                                                         newAIntLiteralExp(FMI_STATUS_LAST_SUCCESSFUL),
                                                                         newARefExp(newAIdentifierExp("fix_recover_real_status")))),
                                                         newAAssignmentStm(newAIdentifierStateDesignator(newAIdentifier(fix_recoveryStepSize)),


### PR DESCRIPTION
This fixes issue #338 which rendered all error handling disabled. The execution would because of this continue after an error statement which was meant to completely stop the execution except for final blocks.

Also fixed a number of related issues found because the error handling started to execute the proper code.