### PR TITLE
Fpm/334

### DIFF
--- a/frameworks/fmi2/src/test/java/SimulationEnvironmentTest.java
+++ b/frameworks/fmi2/src/test/java/SimulationEnvironmentTest.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 public class SimulationEnvironmentTest {
 
     @Test
-    public void simulationConfigurationThrowsWithoutConnections() {
+    public void simConfThrowsWithoutConnections() {
         // Assert
         Assertions.assertThrows(EnvironmentException.class, () -> Fmi2SimulationEnvironmentConfiguration.createFromJsonString(new String(
                 Objects.requireNonNull(this.getClass().getClassLoader()
@@ -18,7 +18,7 @@ public class SimulationEnvironmentTest {
     }
 
     @Test
-    public void simulationConfigurationThrowsWithoutFMUs() {
+    public void simConfThrowsWithoutFMUs() {
         // Assert
         Assertions.assertThrows(EnvironmentException.class, () -> Fmi2SimulationEnvironmentConfiguration.createFromJsonString(new String(
                 Objects.requireNonNull(this.getClass().getClassLoader()
@@ -26,20 +26,10 @@ public class SimulationEnvironmentTest {
     }
 
     @Test
-    public void simulationConfigurationThrowsUnknownName() throws Exception {
-        // Arrange
-        Fmi2SimulationEnvironmentConfiguration simulationConfiguration = Fmi2SimulationEnvironmentConfiguration.createFromJsonString(new String(Objects.requireNonNull(
-                        this.getClass().getClassLoader().getResourceAsStream("simulation_environment/simulation_environment_with_mismatched_names.json"))
-                .readAllBytes()));
-        ErrorReporter reporter = new ErrorReporter();
-
+    public void simConfThrowsOnUnknownFmuNameInConnections() {
         // Act
-        Fmi2SimulationEnvironment.of(simulationConfiguration, reporter);
-        //        Assertions.assertThrows(EnvironmentException.class,
-        //                () -> Fmi2SimulationEnvironmentConfiguration.createFromJsonString(
-        //                        new String(Objects.requireNonNull(
-        //                                this.getClass().getClassLoader().getResourceAsStream("simulation_environment" +
-        //                                        "/simulation_environment_without_fmus" +
-        //                                        ".json")).readAllBytes())));
+        Assertions.assertThrows(EnvironmentException.class, () -> Fmi2SimulationEnvironmentConfiguration.createFromJsonString(new String(
+                Objects.requireNonNull(this.getClass().getClassLoader()
+                        .getResourceAsStream("simulation_environment/simulation_environment_with_mismatched_names.json")).readAllBytes())));
     }
 }

--- a/frameworks/fmi2/src/test/java/SimulationEnvironmentTest.java
+++ b/frameworks/fmi2/src/test/java/SimulationEnvironmentTest.java
@@ -1,7 +1,10 @@
+import org.intocps.maestro.core.messages.ErrorReporter;
 import org.intocps.maestro.framework.core.EnvironmentException;
+import org.intocps.maestro.framework.fmi2.Fmi2SimulationEnvironment;
 import org.intocps.maestro.framework.fmi2.Fmi2SimulationEnvironmentConfiguration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
 import java.util.Objects;
 
 public class SimulationEnvironmentTest {
@@ -9,22 +12,34 @@ public class SimulationEnvironmentTest {
     @Test
     public void simulationConfigurationThrowsWithoutConnections() {
         // Assert
-        Assertions.assertThrows(EnvironmentException.class,
-                () -> Fmi2SimulationEnvironmentConfiguration.createFromJsonString(
-                        new String(Objects.requireNonNull(
-                                this.getClass().getClassLoader().getResourceAsStream("simulation_environment" +
-                                        "/simulation_environment_without_connections" +
-                                        ".json")).readAllBytes())));
+        Assertions.assertThrows(EnvironmentException.class, () -> Fmi2SimulationEnvironmentConfiguration.createFromJsonString(new String(
+                Objects.requireNonNull(this.getClass().getClassLoader()
+                        .getResourceAsStream("simulation_environment" + "/simulation_environment_without_connections" + ".json")).readAllBytes())));
     }
 
     @Test
     public void simulationConfigurationThrowsWithoutFMUs() {
         // Assert
-        Assertions.assertThrows(EnvironmentException.class,
-                () -> Fmi2SimulationEnvironmentConfiguration.createFromJsonString(
-                        new String(Objects.requireNonNull(
-                                this.getClass().getClassLoader().getResourceAsStream("simulation_environment" +
-                                        "/simulation_environment_without_fmus" +
-                                        ".json")).readAllBytes())));
+        Assertions.assertThrows(EnvironmentException.class, () -> Fmi2SimulationEnvironmentConfiguration.createFromJsonString(new String(
+                Objects.requireNonNull(this.getClass().getClassLoader()
+                        .getResourceAsStream("simulation_environment" + "/simulation_environment_without_fmus" + ".json")).readAllBytes())));
+    }
+
+    @Test
+    public void simulationConfigurationThrowsUnknownName() throws Exception {
+        // Arrange
+        Fmi2SimulationEnvironmentConfiguration simulationConfiguration = Fmi2SimulationEnvironmentConfiguration.createFromJsonString(new String(Objects.requireNonNull(
+                        this.getClass().getClassLoader().getResourceAsStream("simulation_environment/simulation_environment_with_mismatched_names.json"))
+                .readAllBytes()));
+        ErrorReporter reporter = new ErrorReporter();
+
+        // Act
+        Fmi2SimulationEnvironment.of(simulationConfiguration, reporter);
+        //        Assertions.assertThrows(EnvironmentException.class,
+        //                () -> Fmi2SimulationEnvironmentConfiguration.createFromJsonString(
+        //                        new String(Objects.requireNonNull(
+        //                                this.getClass().getClassLoader().getResourceAsStream("simulation_environment" +
+        //                                        "/simulation_environment_without_fmus" +
+        //                                        ".json")).readAllBytes())));
     }
 }

--- a/frameworks/fmi2/src/test/resources/simulation_environment/simulation_environment_with_mismatched_names.json
+++ b/frameworks/fmi2/src/test/resources/simulation_environment/simulation_environment_with_mismatched_names.json
@@ -1,0 +1,10 @@
+{
+  "fmus": {
+    "{controllerFMU}": "target/test-classes/watertankcontroller-c.fmu",
+    "{tankFMU}": "target/test-classes/singlewatertank-20sim.fmu"
+  },
+  "connections": {
+    "{controllerFMU}.controller.valve":["{x2}.tank.valvecontrol"],
+    "{tankFMU}.tank.level":["{x1}.controller.level"]
+  }
+}


### PR DESCRIPTION
Fmi2SimulationEnvironmentConfiguration now checks that fmu names found in connections are present in fmus and throws an appropriate exception if it is not.
Closes #334