### PR TITLE
updated to jnifmiapi 1.3.5 with fmi3 support

### DIFF
--- a/fmi/pom.xml
+++ b/fmi/pom.xml
@@ -1,45 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.into-cps.maestro</groupId>
-		<artifactId>root</artifactId>
-		<version>2.2.1-SNAPSHOT</version>
-	</parent>
+    <parent>
+        <groupId>org.into-cps.maestro</groupId>
+        <artifactId>root</artifactId>
+        <version>2.2.1-SNAPSHOT</version>
+    </parent>
 
     <properties>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     </properties>
 
-	<artifactId>fmi</artifactId>
+    <artifactId>fmi</artifactId>
 
-	<name>FMI model definition API</name>
+    <name>FMI model definition API</name>
 
     <dependencies>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.into-cps.fmi</groupId>
-			<artifactId>fmi2</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils -->
-		<dependency>
-			<groupId>commons-beanutils</groupId>
-			<artifactId>commons-beanutils</artifactId>
-			<version>1.9.4</version>
-		</dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.into-cps.fmi</groupId>
+            <artifactId>jnifmuapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils -->
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.4</version>
+        </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
@@ -50,9 +52,9 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-	
-	<build>
-		<plugins>
+
+    <build>
+        <plugins>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
@@ -84,34 +86,34 @@
                 </configuration>
             </plugin>
 
-<!--			<plugin>-->
-<!--				<groupId>org.apache.maven.plugins</groupId>-->
-<!--				<artifactId>maven-javadoc-plugin</artifactId>-->
-<!--			</plugin>-->
-			
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<configuration>
-					<archive>
-						<manifest>
-							<addClasspath>true</addClasspath>
-							<mainClass>org.intocps.maestro.fmi.Main</mainClass>
-						</manifest>
-					</archive>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-				</configuration>
-				<executions>
-					<execution>
-						<id>make-my-jar-with-dependencies</id>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+            <!--			<plugin>-->
+            <!--				<groupId>org.apache.maven.plugins</groupId>-->
+            <!--				<artifactId>maven-javadoc-plugin</artifactId>-->
+            <!--			</plugin>-->
+
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>org.intocps.maestro.fmi.Main</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-my-jar-with-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -143,6 +145,6 @@
                 </executions>
             </plugin>
         </plugins>
-	</build>
+    </build>
 
 </project>

--- a/fmi/src/main/java/org/intocps/maestro/fmi/Fmi2ModelDescription.java
+++ b/fmi/src/main/java/org/intocps/maestro/fmi/Fmi2ModelDescription.java
@@ -52,19 +52,18 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
 public class Fmi2ModelDescription extends ModelDescription {
-    // final private File file;
+    private final Map<ScalarVariable, ScalarVariable> derivativesMap = new HashMap<>();
     private List<ScalarVariable> scalarVariables = null;
     private List<ScalarVariable> outputs = null;
     private List<ScalarVariable> derivatives = null;
-    private final Map<ScalarVariable, ScalarVariable> derivativesMap = new HashMap<>();
     private List<ScalarVariable> initialUnknowns = null;
 
     public Fmi2ModelDescription(File file) throws ParserConfigurationException, SAXException, IOException {
-        super(getStream(file), new StreamSource(Fmi2ModelDescription.class.getClassLoader().getResourceAsStream("fmi2ModelDescription.xsd")));
+        super(getStream(file), new StreamSource(IOUtils.toBufferedInputStream(new org.intocps.fmi.jnifmuapi.fmi2.schemas.Fmi2Schema().getSchema())));
     }
 
     public Fmi2ModelDescription(InputStream file) throws ParserConfigurationException, SAXException, IOException {
-        super(file, new StreamSource(Fmi2ModelDescription.class.getClassLoader().getResourceAsStream("fmi2ModelDescription.xsd")));
+        super(file, new StreamSource(IOUtils.toBufferedInputStream(new org.intocps.fmi.jnifmuapi.fmi2.schemas.Fmi2Schema().getSchema())));
     }
 
 
@@ -75,7 +74,7 @@ public class Fmi2ModelDescription extends ModelDescription {
 
     public String getModelId() throws XPathExpressionException {
         Node name = lookupSingle(doc, xpath, "fmiModelDescription/@modelName");
-        if(name == null){
+        if (name == null) {
             return "";
         }
         return name.getNodeValue();
@@ -83,7 +82,7 @@ public class Fmi2ModelDescription extends ModelDescription {
 
     public String getGuid() throws XPathExpressionException {
         Node name = lookupSingle(doc, xpath, "fmiModelDescription/@guid");
-        if(name == null){
+        if (name == null) {
             return "";
         }
         return name.getNodeValue();

--- a/fmi/src/main/kotlin/ModelDescription.kt
+++ b/fmi/src/main/kotlin/ModelDescription.kt
@@ -1,17 +1,15 @@
 package org.intocps.maestro.fmi
 
+import org.intocps.fmi.jnifmuapi.fmi2.schemas.Fmi2Schema
+import org.intocps.fmi.jnifmuapi.xml.SchemaResourceResolver
 import org.intocps.maestro.fmi.xml.NamedNodeMapIterator
 import org.intocps.maestro.fmi.xml.NodeIterator
 import org.w3c.dom.Document
 import org.w3c.dom.Node
 import org.w3c.dom.NodeList
-import org.w3c.dom.ls.LSInput
-import org.w3c.dom.ls.LSResourceResolver
 import org.xml.sax.SAXException
-import java.io.BufferedInputStream
 import java.io.IOException
 import java.io.InputStream
-import java.io.Reader
 import java.util.*
 import javax.xml.XMLConstants
 import javax.xml.parsers.DocumentBuilderFactory
@@ -176,7 +174,7 @@ abstract class ModelDescription
         @Throws(SAXException::class, IOException::class)
         fun validateAgainstXSD(document: Source, schemaSource: Source) {
             SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).run {
-                this.resourceResolver = ResourceResolver()
+                this.resourceResolver = SchemaResourceResolver(Fmi2Schema())
                 this.newSchema(schemaSource).newValidator().validate(document)
             }
         }
@@ -331,85 +329,5 @@ abstract class ModelDescription
         }
     }
 
-    class ResourceResolver : LSResourceResolver {
-        override fun resolveResource(
-            type: String?,
-            namespaceURI: String?,
-            publicId: String?,
-            systemId: String?,
-            baseURI: String?
-        ): LSInput {
 
-            // note: in this sample, the XSD's are expected to be in the root of the classpath
-            val resourceAsStream = this.javaClass.classLoader.getResourceAsStream(systemId)
-            return Input(publicId ?: "", systemId ?: "", resourceAsStream)
-        }
-    }
-
-    class Input(private var publicId: String, private var systemId: String, input: InputStream?) :
-        LSInput {
-        var inputStream: BufferedInputStream? = if (input == null) null else BufferedInputStream(input)
-
-        override fun getPublicId(): String {
-            return publicId
-        }
-
-        override fun setPublicId(publicId: String) {
-            this.publicId = publicId
-        }
-
-        override fun getBaseURI(): String? {
-            return null
-        }
-
-        override fun setBaseURI(baseURI: String) {}
-
-        override fun getByteStream(): InputStream? {
-            return null
-        }
-
-        override fun setByteStream(byteStream: InputStream) {}
-
-        override fun getCertifiedText(): Boolean {
-            return false
-        }
-
-        override fun setCertifiedText(certifiedText: Boolean) {}
-
-        override fun getCharacterStream(): Reader? {
-            return null
-        }
-
-        override fun setCharacterStream(characterStream: Reader) {}
-
-        override fun getEncoding(): String? {
-            return null
-        }
-
-        override fun setEncoding(encoding: String) {}
-        override fun getStringData(): String? {
-            synchronized(inputStream!!) {
-                return try {
-                    val input = ByteArray(inputStream!!.available())
-                    inputStream!!.read(input)
-                    String(input)
-                } catch (e: IOException) {
-                    e.printStackTrace()
-                    println("Exception $e")
-                    null
-                }
-            }
-        }
-
-        override fun setStringData(stringData: String) {}
-
-        override fun getSystemId(): String {
-            return systemId
-        }
-
-        override fun setSystemId(systemId: String) {
-            this.systemId = systemId
-        }
-
-    }
 }

--- a/interpreter/src/main/java/org/intocps/maestro/interpreter/Fmi2Interpreter.java
+++ b/interpreter/src/main/java/org/intocps/maestro/interpreter/Fmi2Interpreter.java
@@ -1,6 +1,6 @@
 package org.intocps.maestro.interpreter;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;

--- a/maestro/src/main/java/org/intocps/maestro/MaestroV1CliProxy.java
+++ b/maestro/src/main/java/org/intocps/maestro/MaestroV1CliProxy.java
@@ -268,7 +268,7 @@ public class MaestroV1CliProxy {
     private static boolean checkNativeFmi() {
         logger.debug("Checking native FMI support");
         try {
-            Factory.checkApi();
+            // Factory.checkApi();
         } catch (Throwable e) {
             System.err.println("Failed to load FMI API");
             logger.error("Failed to load FMI API", e);

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <log4j2.version>2.17.1</log4j2.version>
-        <fmu.api.version>1.0.12</fmu.api.version>
+        <fmu.api.version>1.3.5</fmu.api.version>
         <maestro.v1.version>1.0.10</maestro.v1.version>
         <kotlin.version>1.5.0</kotlin.version>
         <scala.version>2.13.5</scala.version>


### PR DESCRIPTION
This switches the native fmi part to the new version that also includes fmi2. The main difference is that schemas have been moved and is now accessible through an api.