### PR TITLE
Add import support for FMI3 models with events

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ env:
   PYTHON_VERSION: '3.12.2'
   MAVEN_VERSION: 3.8.1
   WINDOWS_VERSION: 'windows-latest'
-  MACOS_VERSION: 'macos-13'
+  MACOS_VERSION: 'macos-15'
 
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, windows-latest, macos-13 ]
+        os: [ ubuntu-22.04, windows-latest, macos-15 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,6 @@ env:
   PYTHON_VERSION: '3.12.2'
   MAVEN_VERSION: 3.8.1
   WINDOWS_VERSION: 'windows-latest'
-  MACOS_VERSION: 'macos-15'
 
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
@@ -29,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, windows-latest, macos-15 ]
+        os: [ ubuntu-22.04, windows-latest, macos-15-intel ]
 
     steps:
       - uses: actions/checkout@v2
@@ -46,17 +45,42 @@ jobs:
         with:
           maven-version: ${{ ENV.MAVEN_VERSION }}
 
-      - name: Put MSYS2_MinGW64 on PATH for windows
-        if: ${{matrix.os == env.WINDOWS_VERSION }}
-        # there is not yet an environment variable for this path from msys2/setup-msys2
-        # We need this to get a gcc 11.2 that is new enough to compile the reference FMU3
-        run: echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: Install C++ toolchain
+      - name: '${{ matrix.icon }} Setup MSYS2'
         if: runner.os == 'Windows'
-        shell: msys2 {0}
-        run: |
-          pacman -S --noconfirm mingw-w64-ucrt-x86_64-gcc
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          path-type: inherit
+          install: >-
+            git
+            make
+            mingw-w64-ucrt-x86_64-zlib
+            mingw-w64-ucrt-x86_64-libzip
+            mingw-w64-ucrt-x86_64-gcc
+
+          pacboy: >-
+            toolchain:p
+            cmake:p
+            ninja:p
+
+#      - name: Put MSYS2 on PATH
+#        if: runner.os == 'Windows'
+#        run: |
+#          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+#
+#      - name: Install C++ toolchain
+#        if: runner.os == 'Windows'
+#        shell: msys2 {0}
+#        run: |
+#          pacman -S --noconfirm mingw-w64-ucrt-x86_64-gcc
+#
+#      - name: Put MSYS2_MinGW64 on PATH for windows
+#        if: ${{matrix.os == env.WINDOWS_VERSION }}
+#        # there is not yet an environment variable for this path from msys2/setup-msys2
+#        # We need this to get a gcc 11.2 that is new enough to compile the reference FMU3
+#        run: echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
 
       - name: Install vcpkg
         if: ${{matrix.os == env.WINDOWS_VERSION }}
@@ -68,6 +92,9 @@ jobs:
         if: ${{matrix.os == env.WINDOWS_VERSION }}
         run: .\vcpkg\vcpkg install zlib
 
+      - name: Install latest CMake
+        if: matrix.os == 'macos-15-intel'
+        run: brew install cmake
 
       - name: Cache local Maven repository
         uses: actions/cache@v3
@@ -82,12 +109,16 @@ jobs:
 
       - name: Maven Test
         if: matrix.os == env.WINDOWS_VERSION
+        shell: msys2 {0}
         env:
           ZLIB_ROOT: ${{ github.workspace }}\vcpkg\installed\x64-windows
           ZLIB_LIBRARY: ${{ github.workspace }}\vcpkg\installed\x64-windows\lib\zlib.lib
           ZLIB_INCLUDE_DIR: ${{ github.workspace }}\vcpkg\installed\x64-windows\include
           CMAKE_PREFIX_PATH: ${{ github.workspace }}\vcpkg\installed\x64-windows
-        run: mvn -Pinclude-fullSpecCppTest test
+        run: |
+          export PATH="$(/usr/bin/cygpath -u "$PATH"):$PATH"
+
+          mvn -Pinclude-fullSpecCppTest test
 
       - name: Maven Test
         if: matrix.os != env.WINDOWS_VERSION

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -50,7 +50,13 @@ jobs:
         if: ${{matrix.os == env.WINDOWS_VERSION }}
         # there is not yet an environment variable for this path from msys2/setup-msys2
         # We need this to get a gcc 11.2 that is new enough to compile the reference FMU3
-        run: echo "C:\msys64/mingw64/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install C++ toolchain
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: |
+          pacman -S --noconfirm mingw-w64-ucrt-x86_64-gcc
 
       - name: Install vcpkg
         if: ${{matrix.os == env.WINDOWS_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ env:
   PYTHON_VERSION: '3.11.8'
   MAVEN_VERSION: 3.8.1
   WINDOWS_VERSION: 'windows-latest'
-  MACOS_VERSION: 'macos-13'
+  MACOS_VERSION: 'macos-15'
 
 
 
@@ -111,10 +111,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, windows-latest, macos-13 ] # ubuntu-latest, , macos-13
+        os: [ ubuntu-22.04, windows-latest, macos-13 ] # ubuntu-latest, , macos-15
         platform: [ x64 ] #x32, x64 ]
         exclude:
-          - os: macos-13
+          - os: macos-15
             platform: x32
     steps:
       - uses: actions/checkout@v2

--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2007-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.net.*;
+import java.io.*;
+import java.nio.channels.*;
+import java.util.Properties;
+
+public class MavenWrapperDownloader {
+
+    private static final String WRAPPER_VERSION = "0.5.6";
+    /**
+     * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
+     */
+    private static final String DEFAULT_DOWNLOAD_URL = "https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/"
+        + WRAPPER_VERSION + "/maven-wrapper-" + WRAPPER_VERSION + ".jar";
+
+    /**
+     * Path to the maven-wrapper.properties file, which might contain a downloadUrl property to
+     * use instead of the default one.
+     */
+    private static final String MAVEN_WRAPPER_PROPERTIES_PATH =
+            ".mvn/wrapper/maven-wrapper.properties";
+
+    /**
+     * Path where the maven-wrapper.jar will be saved to.
+     */
+    private static final String MAVEN_WRAPPER_JAR_PATH =
+            ".mvn/wrapper/maven-wrapper.jar";
+
+    /**
+     * Name of the property which should be used to override the default download url for the wrapper.
+     */
+    private static final String PROPERTY_NAME_WRAPPER_URL = "wrapperUrl";
+
+    public static void main(String args[]) {
+        System.out.println("- Downloader started");
+        File baseDirectory = new File(args[0]);
+        System.out.println("- Using base directory: " + baseDirectory.getAbsolutePath());
+
+        // If the maven-wrapper.properties exists, read it and check if it contains a custom
+        // wrapperUrl parameter.
+        File mavenWrapperPropertyFile = new File(baseDirectory, MAVEN_WRAPPER_PROPERTIES_PATH);
+        String url = DEFAULT_DOWNLOAD_URL;
+        if(mavenWrapperPropertyFile.exists()) {
+            FileInputStream mavenWrapperPropertyFileInputStream = null;
+            try {
+                mavenWrapperPropertyFileInputStream = new FileInputStream(mavenWrapperPropertyFile);
+                Properties mavenWrapperProperties = new Properties();
+                mavenWrapperProperties.load(mavenWrapperPropertyFileInputStream);
+                url = mavenWrapperProperties.getProperty(PROPERTY_NAME_WRAPPER_URL, url);
+            } catch (IOException e) {
+                System.out.println("- ERROR loading '" + MAVEN_WRAPPER_PROPERTIES_PATH + "'");
+            } finally {
+                try {
+                    if(mavenWrapperPropertyFileInputStream != null) {
+                        mavenWrapperPropertyFileInputStream.close();
+                    }
+                } catch (IOException e) {
+                    // Ignore ...
+                }
+            }
+        }
+        System.out.println("- Downloading from: " + url);
+
+        File outputFile = new File(baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_JAR_PATH);
+        if(!outputFile.getParentFile().exists()) {
+            if(!outputFile.getParentFile().mkdirs()) {
+                System.out.println(
+                        "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() + "'");
+            }
+        }
+        System.out.println("- Downloading to: " + outputFile.getAbsolutePath());
+        try {
+            downloadFileFromURL(url, outputFile);
+            System.out.println("Done");
+            System.exit(0);
+        } catch (Throwable e) {
+            System.out.println("- Error downloading");
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    private static void downloadFileFromURL(String urlString, File destination) throws Exception {
+        if (System.getenv("MVNW_USERNAME") != null && System.getenv("MVNW_PASSWORD") != null) {
+            String username = System.getenv("MVNW_USERNAME");
+            char[] password = System.getenv("MVNW_PASSWORD").toCharArray();
+            Authenticator.setDefault(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication(username, password);
+                }
+            });
+        }
+        URL website = new URL(urlString);
+        ReadableByteChannel rbc;
+        rbc = Channels.newChannel(website.openStream());
+        FileOutputStream fos = new FileOutputStream(destination);
+        fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+        fos.close();
+        rbc.close();
+    }
+
+}

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,2 @@
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/ast/src/main/java/org/intocps/maestro/ast/LexLocation.java
+++ b/ast/src/main/java/org/intocps/maestro/ast/LexLocation.java
@@ -1,0 +1,55 @@
+package org.intocps.maestro.ast;
+
+import org.intocps.maestro.ast.node.ExternalNode;
+
+import java.util.Objects;
+
+public class LexLocation implements ExternalNode {
+    private final int line;
+    private final int pos;
+    private final String filename;
+
+    public LexLocation(String filename, int line, int pos) {
+        this.filename = filename;
+        this.line = line;
+        this.pos = pos;
+    }
+
+    public LexLocation(LexLocation other) {
+        if (other == null) {
+            this.filename = "Unknown";
+            this.line = 0;
+            this.pos = 0;
+
+        } else {
+            this.filename = other.filename;
+            this.line = other.line;
+            this.pos = other.pos;
+        }
+    }
+
+    @Override
+    public Object clone() {
+        return new LexLocation(filename, line, pos);
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LexLocation that = (LexLocation) o;
+        return line == that.line && pos == that.pos && Objects.equals(filename, that.filename);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(line, pos, filename);
+    }
+
+    @Override
+    public String toString() {
+        return filename + ":" + line + ":" + pos;
+    }
+}

--- a/ast/src/main/resources/mabl.astv2
+++ b/ast/src/main/resources/mabl.astv2
@@ -140,6 +140,7 @@ stm
     | {fmuMapping} [identifier]:lex_identifier [name]:java_String
     | {transfer} [names]:exp.#literal.string*
     | {transferAs} [names]:exp.#literal.string*
+    | {debug} [tokens]:exp.#literal.string*
     | {config} [config]:java_String
     | {error} [exp]:exp
     | {try} [body]:stm.#block.basic [finally]:stm.#block.basic

--- a/ast/src/main/resources/mabl.astv2
+++ b/ast/src/main/resources/mabl.astv2
@@ -18,6 +18,7 @@ Tokens
     java_Float = 'java:java.lang.Float';
     java_Long = 'java:java.lang.Long';
     lex_identifier='java:org.intocps.maestro.ast.LexIdentifier';
+    lex_location='java:org.intocps.maestro.ast.LexLocation';
 
     parserToken = 'java:node:org.intocps.maestro.ast.LexToken';
 
@@ -72,7 +73,7 @@ parameter
 
 
 
-exp
+exp { -> package='org.intocps.maestro.ast.node' | [location]:lex_location}
     = {identifier} [name]:lex_identifier
     | #literal
     | {load} [args]:exp*

--- a/ast/src/main/resources/mabl.astv2.tostring
+++ b/ast/src/main/resources/mabl.astv2.tostring
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 %exp->#binary->plus = [left]+ " + " + [right]
 %exp->#binary->minus = [left]+ " - " + [right]
 %exp->#binary->lessEqual = [left]+ " <= " + [right]
-%exp->#binary->greaterEqual = [left]+ " > " + [right]
+%exp->#binary->greaterEqual = [left]+ " >= " + [right]
 %exp->#binary->less = [left]+ " < " + [right]
 %exp->#binary->greater = [left]+ " > " + [right]
 %exp->#binary->equal = [left]+ " == " + [right]
@@ -66,6 +66,7 @@ import java.util.stream.Collectors;
 %stm->fmuMapping = "@mapFmu(" + [identifier]+ " -> \""+[name] + "\")"
 %stm->transfer = "@Transfer("  +$$[names]$.stream().map(Object::toString).collect(Collectors.joining(","))$+   ")"
 %stm->transferAs = "@TransferAs("  +$$[names]$.stream().map(Object::toString).collect(Collectors.joining(","))$+   ")"
+%stm->debug = "@Debug("  +$$[tokens]$.stream().map(Object::toString).collect(Collectors.joining(","))$+   ")"
 %stm->config = "@Config(\"" + [config] + "\")"
 %stm->error = "error "+ $ ($[exp]$==null?"":$[exp]$)$
 %stm->try = "try" + [body] +  "finally"  +[finally]

--- a/codegen/mabl2cpp/src/main/java/org/intocps/maestro/codegen/mabl2cpp/CppPrinter.java
+++ b/codegen/mabl2cpp/src/main/java/org/intocps/maestro/codegen/mabl2cpp/CppPrinter.java
@@ -55,7 +55,7 @@ class CppPrinter extends DepthFirstAnalysisAdaptorQuestion<Integer> {
         //inject config path for MEnv
         List<PExp> arguments =
                 name.getValue().equals("MEnv") || name.getValue().equals("DataWriter") ? Stream.concat(node.getArgs().stream().limit(1),
-                                Stream.concat(Stream.of(new AIdentifierExp(new LexIdentifier("__runtimeConfigPath", null))), node.getArgs().stream().skip(1)))
+                                Stream.concat(Stream.of(new AIdentifierExp(new LexLocation("",0,0),new LexIdentifier("__runtimeConfigPath", null))), node.getArgs().stream().skip(1)))
                         .collect(Collectors.toList()) : node.getArgs();
         for (int i = 1; i < arguments.size(); i++) {
             if (i > 1) {

--- a/codegen/mabl2cpp/src/main/resources/org/intocps/maestro/codegen/mabl2cpp/CMakeLists.txt
+++ b/codegen/mabl2cpp/src/main/resources/org/intocps/maestro/codegen/mabl2cpp/CMakeLists.txt
@@ -25,43 +25,58 @@ SET(BUILD_EXAMPLES OFF CACHE BOOL "Build examples")
 SET(BUILD_DOC OFF CACHE BOOL "Build documentation")
 SET(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
 
-FetchContent_Declare(libzip
-        GIT_REPOSITORY https://github.com/nih-at/libzip.git
-        GIT_TAG  v1.11
-        GIT_SHALLOW ON
-        SOURCE_DIR "${CMAKE_BINARY_DIR}/libzip"
-        EXCLUDE_FROM_ALL
+#if(NOT MINGW)
+
+    FetchContent_Declare(libzip
+            GIT_REPOSITORY https://github.com/nih-at/libzip.git
+            GIT_TAG  v1.11.4
+            GIT_SHALLOW ON
+            SOURCE_DIR "${CMAKE_BINARY_DIR}/libzip"
+            EXCLUDE_FROM_ALL
+    )
+
+
+    set(ENABLE_GNUTLS OFF CACHE BOOL "")
+    set(ENABLE_MBEDTLS OFF CACHE BOOL "")
+    set(ENABLE_OPENSSL OFF CACHE BOOL "")
+    set(ENABLE_WINDOWS_CRYPTO OFF CACHE BOOL "")
+
+    set(BUILD_TOOLS OFF CACHE BOOL "")
+    set(BUILD_REGRESS OFF CACHE BOOL "")
+    set(BUILD_EXAMPLES OFF CACHE BOOL "")
+    set(BUILD_DOC OFF CACHE BOOL "")
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "")
+
+    FetchContent_MakeAvailable(libzip )
+#else()
+
+
+#find_package(PkgConfig REQUIRED)
+#set(PKG_CONFIG_USE_STATIC_LIBS ON)
+#pkg_check_modules(LIBZIP REQUIRED libzip)
+
+# Use static libs
+
+
+
+  #  find_library(LIBZIP_LIBRARY
+  #               NAMES libzip.a zip
+  #               PATHS "${MINGW_PREFIX}/lib"
+  #               NO_DEFAULT_PATH)
+  #  add_library(zip STATIC IMPORTED)
+  #  set_target_properties(zip PROPERTIES IMPORTED_LOCATION ${LIBZIP_LIBRARY})
+
+
+#endif()
+
+
+
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
+    DOWNLOAD_EXTRACT_TIMESTAMP FALSE
 )
+FetchContent_MakeAvailable(json)
 
 
-set(ENABLE_GNUTLS OFF CACHE BOOL "")
-set(ENABLE_MBEDTLS OFF CACHE BOOL "")
-set(ENABLE_OPENSSL OFF CACHE BOOL "")
-set(ENABLE_WINDOWS_CRYPTO OFF CACHE BOOL "")
-
-set(BUILD_TOOLS OFF CACHE BOOL "")
-set(BUILD_REGRESS OFF CACHE BOOL "")
-set(BUILD_EXAMPLES OFF CACHE BOOL "")
-set(BUILD_DOC OFF CACHE BOOL "")
-set(BUILD_SHARED_LIBS OFF CACHE BOOL "")
-
-FetchContent_MakeAvailable(libzip )
-
-SET(RAPIDJSON_BUILD_EXAMPLES OFF CACHE BOOL "Build rapidjson examples" FORCE)
-SET(RAPIDJSON_BUILD_TESTS OFF CACHE BOOL "Build rapidjson perftests and unittests" FORCE)
-FetchContent_Declare(rapidjson
-        GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
-        GIT_TAG 7c73dd7de7c4f14379b781418c6e947ad464c818 # this hash seems to make it work on windows (nix works with v1.1.0)
-     #   GIT_SHALLOW ON
-        SOURCE_DIR "${CMAKE_BINARY_DIR}/rapidjson"
-        BUILD_COMMAND ""
-        CONFIGURE_COMMAND ""
-        INSTALL_COMMAND ""
-        TEST_COMMAND ""
-        EXCLUDE_FROM_ALL
-        )
-
-FetchContent_MakeAvailable(rapidjson )
 
 #file(CHMOD_RECURSE "${CMAKE_BINARY_DIR}/rapidjson" PERMISSIONS OWNER_READ OWNER_WRITE  GROUP_READ GROUP_WRITE WORLD_READ WORLD_WRITE )
 
@@ -69,8 +84,7 @@ include_directories(${PROJECT_SOURCE_DIR}
     ${intocpsfmi_SOURCE_DIR}/jnifmuapi/src/main/native/src/external/shared/fmi/include
     ${intocpsfmi_SOURCE_DIR}/jnifmuapi/src/main/native/src/external/shared
     ${intocpsfmi_SOURCE_DIR}/jnifmuapi/src/main/native/src
-    ${PROJECT_SOURCE_DIR}/libs
-    ${rapidjson_SOURCE_DIR}/include)
+    ${PROJECT_SOURCE_DIR}/libs)
 
 
 add_executable(sim
@@ -88,7 +102,17 @@ add_executable(sim
     co-sim.cxx
     main.cpp)
 
-target_link_libraries(sim zip )
+target_link_libraries(sim nlohmann_json::nlohmann_json)
+#if (MINGW)
+
+#    target_include_directories(sim PUBLIC ${LIBZIP_INCLUDE_DIRS})
+#    target_link_libraries(sim  ${LIBZIP_STATIC_LIBRARIES})
+#    target_compile_definitions(sim PRIVATE _HAS_QUICK_EXIT=0)
+
+#else()
+    target_link_libraries(sim zip )
+#endif()
+
 target_compile_definitions(sim PRIVATE -DFMI_COSIMULATION)
 
 if (UNIX)

--- a/codegen/mabl2cpp/src/main/resources/org/intocps/maestro/codegen/mabl2cpp/libs/DataWriter.cpp
+++ b/codegen/mabl2cpp/src/main/resources/org/intocps/maestro/codegen/mabl2cpp/libs/DataWriter.cpp
@@ -1,11 +1,11 @@
 #include "DataWriter.h"
 #include <filesystem>
 
-#include <rapidjson/document.h>
-#include <fstream>
-#include <rapidjson/istreamwrapper.h>
 
-using namespace rapidjson;
+#include <fstream>
+
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
 
 DataWriter load_DataWriter(const char *runtimeConfigPath) {
 
@@ -17,20 +17,17 @@ DataWriter load_DataWriter(const char *runtimeConfigPath) {
         using namespace std;
 
         ifstream ifs(runtimeConfigPath);
-        IStreamWrapper isw(ifs);
+        json d = json::parse(ifs);
 
-        Document d;
-        d.ParseStream(isw);
+        if (d.is_object()) {
+            if (d.contains("DataWriter") && d["DataWriter"].is_array()) {
 
-        if (d.IsObject()) {
-            if (d.HasMember("DataWriter") && d["DataWriter"].IsArray()) {
+                for (auto &v : d["DataWriter"]) {
+                    if (v.is_object()) {
 
-                for (auto &v : d["DataWriter"].GetArray()) {
-                    if (v.IsObject()) {
-
-                        if(v.HasMember("type")&& strcmp(v["type"].GetString(),"CSV")==0 && v.HasMember("filename"))
+                        if(v.contains("type")&& strcmp(v["type"].get<std::string>().c_str(),"CSV")==0 && v.contains("filename"))
                         {
-                            csvPath=v["filename"].GetString();
+                            csvPath=v["filename"].get<std::string>();
                             break;
                         }
                     }

--- a/codegen/mabl2cpp/src/main/resources/org/intocps/maestro/codegen/mabl2cpp/libs/MEnv.cpp
+++ b/codegen/mabl2cpp/src/main/resources/org/intocps/maestro/codegen/mabl2cpp/libs/MEnv.cpp
@@ -13,14 +13,12 @@ MEnvImpl::MEnvImpl(const char *runtimeConfigPath) {
         using namespace std;
 
         ifstream ifs(this->runtimeConfigPath);
-        IStreamWrapper isw(ifs);
 
-        Document d;
-        d.ParseStream(isw);
+        auto d = nj::parse(ifs);
 
-        if (d.IsObject()) {
-            if (d.HasMember("environment_variables") && d["environment_variables"].IsObject()) {
-                this->json.CopyFrom(d["environment_variables"], this->json.GetAllocator());
+        if (d.is_object()) {
+            if (d.contains("environment_variables") && d["environment_variables"].is_object()) {
+                this->json["environment_variables"]=d["environment_variables"];
             }
         }
     }
@@ -36,13 +34,13 @@ std::string toEnvName(const char *name) {
 
 fmi2Real MEnvImpl::getReal(const char *id) {
     auto value = std::getenv(toEnvName(id).c_str());
-    if (value == nullptr && this->json.IsObject()) {
-        if (this->json.HasMember(id)) {
-            if (this->json[id].IsNumber()) {
-                if (this->json[id].IsDouble()) {
-                    return this->json[id].GetDouble();
-                } else if (this->json[id].IsInt()) {
-                    return this->json[id].GetInt();
+    if (value == nullptr && this->json.is_object()) {
+        if (this->json.contains(id)) {
+            if (this->json[id].is_number()) {
+                if (this->json[id].is_number_float()) {
+                    return this->json[id].get<double>();
+                } else if (this->json[id].is_number_integer()) {
+                    return this->json[id].get<int>();
                 }
             }
         }
@@ -59,10 +57,10 @@ fmi2Real MEnvImpl::getReal(const char *id) {
 fmi2String MEnvImpl::getString(const char *id) {
     auto value = std::getenv(toEnvName(id).c_str());
 
-    if (value == nullptr && this->json.IsObject()) {
-        if (this->json.HasMember(id)) {
-            if (this->json[id].IsString()) {
-                return this->json[id].GetString();
+    if (value == nullptr && this->json.is_object()) {
+        if (this->json.contains(id)) {
+            if (this->json[id].is_string()) {
+                return strdup(this->json[id].get<std::string>().c_str());
             }
         }
     }
@@ -78,13 +76,13 @@ fmi2String MEnvImpl::getString(const char *id) {
 fmi2Boolean MEnvImpl::getBool(const char *id) {
     auto value = std::getenv(toEnvName(id).c_str());
 
-    if (value == nullptr && this->json.IsObject()) {
-        if (this->json.HasMember(id)) {
-            if (this->json[id].IsInt() || this->json[id].IsBool()) {
-                if (this->json[id].IsBool()) {
-                    return this->json[id].GetBool();
-                } else if (this->json[id].IsInt()) {
-                    return this->json[id].GetInt();
+    if (value == nullptr && this->json.is_object()) {
+        if (this->json.contains(id)) {
+            if (this->json[id].is_number_integer() || this->json[id].is_boolean()) {
+                if (this->json[id].is_boolean()) {
+                    return this->json[id].get<double>();
+                } else if (this->json[id].is_number_integer()) {
+                    return this->json[id].get<int>();
                 }
             }
         }
@@ -102,11 +100,11 @@ fmi2Boolean MEnvImpl::getBool(const char *id) {
 fmi2Integer MEnvImpl::getInt(const char *id) {
     auto value = std::getenv(toEnvName(id).c_str());
 
-    if (value == nullptr && this->json.IsObject()) {
-        if (this->json.HasMember(id)) {
-            if (this->json[id].IsNumber()) {
-                if (this->json[id].IsInt()) {
-                    return this->json[id].GetInt();
+    if (value == nullptr && this->json.is_object()) {
+        if (this->json.contains(id)) {
+            if (this->json[id].is_number()) {
+                if (this->json[id].is_number_integer()) {
+                    return this->json[id].get<int>();
                 }
             }
         }

--- a/codegen/mabl2cpp/src/main/resources/org/intocps/maestro/codegen/mabl2cpp/libs/MEnv.h
+++ b/codegen/mabl2cpp/src/main/resources/org/intocps/maestro/codegen/mabl2cpp/libs/MEnv.h
@@ -15,13 +15,13 @@
 #include <cctype>
 #include <filesystem>
 
-#include <rapidjson/document.h>
 #include <fstream>
-#include <rapidjson/istreamwrapper.h>
+#include <nlohmann/json.hpp>
+
+using nj = nlohmann::json;
 
 
 
-using namespace rapidjson;
 class MEnvImpl {
 private:
     bool to_bool(std::string str) {
@@ -33,7 +33,7 @@ private:
     }
 
     const char* runtimeConfigPath;
-    Document json;
+    nj json;
 
 public:
     MEnvImpl(const char* runtimeConfigPath) ;

--- a/fmi/src/main/kotlin/org/intocps/maestro/fmi/fmi3/Fmi3Variables.kt
+++ b/fmi/src/main/kotlin/org/intocps/maestro/fmi/fmi3/Fmi3Variables.kt
@@ -19,6 +19,10 @@ abstract class Fmi3Variable protected constructor(
         return valueReference.toLong()
     }
 
+    fun getClocksAsLong(): List<Long>? {
+        return clocks?.map { it.toLong() }
+    }
+
     override fun toString(): String {
         return "$name: ${typeIdentifier.name}"
     }

--- a/frameworks/builder/src/main/java/org/intocps/maestro/framework/fmi2/api/FmiBuilder.java
+++ b/frameworks/builder/src/main/java/org/intocps/maestro/framework/fmi2/api/FmiBuilder.java
@@ -803,7 +803,14 @@ public interface FmiBuilder<AST, B, E, SETTINGS> {
         void terminate();
 
 
+         Map<? extends Port<PORT_SCALAR_TYPE, AST>, ? extends DoubleVariable<AST>> getClockInterval(Scope<AST> scope, Port<PORT_SCALAR_TYPE, AST>... port);
+        DoubleVariable<AST> getClockShift(FmiBuilder.Port<PORT_SCALAR_TYPE, AST> port);
+
+
+//        public <V> Map<PortFmi3Api, DoubleVariableFmi2Api<V>> getClockInterval(FmiBuilder.Scope<PStm> scope,
+//                                                                               FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm>... ports)
     }
+
 
     /**
      * Interface for an fmi component.

--- a/frameworks/builder/src/main/java/org/intocps/maestro/framework/fmi2/api/FmiBuilder.java
+++ b/frameworks/builder/src/main/java/org/intocps/maestro/framework/fmi2/api/FmiBuilder.java
@@ -804,8 +804,10 @@ public interface FmiBuilder<AST, B, E, SETTINGS> {
 
 
          Map<? extends Port<PORT_SCALAR_TYPE, AST>, ? extends DoubleVariable<AST>> getClockInterval(Scope<AST> scope, Port<PORT_SCALAR_TYPE, AST>... port);
-        DoubleVariable<AST> getClockShift(FmiBuilder.Port<PORT_SCALAR_TYPE, AST> port);
+        Map<? extends Port<PORT_SCALAR_TYPE, AST>, ? extends DoubleVariable<AST>> getClockShift(Scope<AST> scope,FmiBuilder.Port<PORT_SCALAR_TYPE, AST>... port);
 
+        void setClockInterval(Scope<AST> scope, Port<PORT_SCALAR_TYPE, AST> port, DoubleExpressionValue value);
+         void setClockShift(Scope<AST> scope,FmiBuilder.Port<PORT_SCALAR_TYPE, AST> port, DoubleExpressionValue value);
 
 //        public <V> Map<PortFmi3Api, DoubleVariableFmi2Api<V>> getClockInterval(FmiBuilder.Scope<PStm> scope,
 //                                                                               FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm>... ports)

--- a/frameworks/fmi2/src/main/java/org/intocps/maestro/framework/fmi2/Fmi2SimulationEnvironment.java
+++ b/frameworks/fmi2/src/main/java/org/intocps/maestro/framework/fmi2/Fmi2SimulationEnvironment.java
@@ -749,7 +749,11 @@ public class Fmi2SimulationEnvironment implements ISimulationEnvironment, ISimul
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(is);
             doc.getDocumentElement().normalize();
-            return Double.parseDouble((String) xPath.compile("fmiModelDescription/@fmiVersion").evaluate(doc, XPathConstants.STRING));
+            var version =(String) xPath.compile("fmiModelDescription/@fmiVersion").evaluate(doc, XPathConstants.STRING);
+            if(version.contains("-")){
+                version = version.substring(0, version.indexOf("-"));
+            }
+            return Double.parseDouble(version);
         }
 
         @Override

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/BuilderUtil.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/BuilderUtil.java
@@ -12,17 +12,18 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.function.Supplier;
 
 import static org.intocps.maestro.ast.MableAstFactory.*;
 
 public class BuilderUtil {
     final static Logger logger = LoggerFactory.getLogger(BuilderUtil.class);
 
-    public static List<PStm> createTypeConvertingAssignment(PStateDesignator designator, PExp value, PType valueType,final PType targetType) {
+    public static List<PStm> createTypeConvertingAssignment(PStateDesignator designator_, PExp value_, PType valueType,final PType targetType) {
 
         //make sure we dont take the nodes
-        designator = designator.clone();
-        value = value.clone();
+      Supplier<PStateDesignator>       designator =()-> designator_.clone();
+        Supplier<  PExp  > value=()-> value_.clone();
         valueType = valueType.clone();
 
 
@@ -30,7 +31,7 @@ public class BuilderUtil {
         List<PStm> statements = new Vector<>();
         TypeComparator typeComparator = new TypeComparator();
         if (typeComparator.compatible(targetType, valueType)) {
-            statements.add(newAAssignmentStm(designator, value));
+            statements.add(newAAssignmentStm(designator.get(), value.get()));
         } else {
 
             //   String varName = builder.getNameGenerator().getName();
@@ -39,7 +40,7 @@ public class BuilderUtil {
             if (typeComparator.compatible(newRealType(), valueType) && typeComparator.compatible(new AFloatNumericPrimitiveType(), targetType)) {
                 // real to float
 
-                statements.add(newAAssignmentStm(designator, value));
+                statements.add(newAAssignmentStm(designator.get(), value.get()));
 
             } else if (typeComparator.compatible(newBoleanType(), valueType) && (typeComparator.compatible(newRealType(), targetType)) ||
                     typeComparator.compatible(newRealType(), targetType) || typeComparator.compatible(newRealType(), targetType)) {
@@ -53,21 +54,21 @@ public class BuilderUtil {
                     falseToken = newARealLiteralExp(0d);
                 }
 
-                statements.add(newIf(value, newAAssignmentStm(designator, trueToken), newAAssignmentStm(designator, falseToken)));
+                statements.add(newIf(value.get(), newAAssignmentStm(designator.get(), trueToken), newAAssignmentStm(designator.get(), falseToken)));
             } else if (typeComparator.compatible(newBoleanType(), targetType) && (typeComparator.compatible(newRealType(), valueType)) ||
                     typeComparator.compatible(newRealType(), valueType) || typeComparator.compatible(newRealType(), valueType)) {
                 // number to bool
-                statements.add(newAAssignmentStm(designator, newEqual(value, newAIntLiteralExp(1))));
+                statements.add(newAAssignmentStm(designator.get(), newEqual(value.get(), newAIntLiteralExp(1))));
 
             } else if ((typeComparator.compatible(newIntType(), valueType) || typeComparator.compatible(newUIntType(), valueType)) &&
                     (typeComparator.compatible(newIntType(), targetType) || typeComparator.compatible(newUIntType(), targetType))) {
                 // (u)int to (u)int
-                statements.add(newAAssignmentStm(designator, value));
+                statements.add(newAAssignmentStm(designator.get(), value.get()));
             } else {
                 //FIXME type conversion missing
                 logger.error("No implementation for type conversion");
                 //no solution so lets make the type checker report this error for now
-                statements.add(newAAssignmentStm(designator, value));
+                statements.add(newAAssignmentStm(designator.get(), value.get()));
             }
 
 

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/BuilderUtil.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/BuilderUtil.java
@@ -18,7 +18,14 @@ import static org.intocps.maestro.ast.MableAstFactory.*;
 public class BuilderUtil {
     final static Logger logger = LoggerFactory.getLogger(BuilderUtil.class);
 
-    public static List<PStm> createTypeConvertingAssignment(PStateDesignator designator, PExp value, PType valueType, PType targetType) {
+    public static List<PStm> createTypeConvertingAssignment(PStateDesignator designator, PExp value, PType valueType,final PType targetType) {
+
+        //make sure we dont take the nodes
+        designator = designator.clone();
+        value = value.clone();
+        valueType = valueType.clone();
+
+
 
         List<PStm> statements = new Vector<>();
         TypeComparator typeComparator = new TypeComparator();
@@ -46,11 +53,11 @@ public class BuilderUtil {
                     falseToken = newARealLiteralExp(0d);
                 }
 
-                statements.add(newIf(value, newAAssignmentStm(designator.clone(), trueToken), newAAssignmentStm(designator.clone(), falseToken)));
+                statements.add(newIf(value, newAAssignmentStm(designator, trueToken), newAAssignmentStm(designator, falseToken)));
             } else if (typeComparator.compatible(newBoleanType(), targetType) && (typeComparator.compatible(newRealType(), valueType)) ||
                     typeComparator.compatible(newRealType(), valueType) || typeComparator.compatible(newRealType(), valueType)) {
                 // number to bool
-                statements.add(newAAssignmentStm(designator.clone(), newEqual(value, newAIntLiteralExp(1))));
+                statements.add(newAAssignmentStm(designator, newEqual(value, newAIntLiteralExp(1))));
 
             } else if ((typeComparator.compatible(newIntType(), valueType) || typeComparator.compatible(newUIntType(), valueType)) &&
                     (typeComparator.compatible(newIntType(), targetType) || typeComparator.compatible(newUIntType(), targetType))) {

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/ExpansionMableApiBuilder.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/ExpansionMableApiBuilder.java
@@ -1,0 +1,219 @@
+package org.intocps.maestro.framework.fmi2.api.mabl;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.intocps.maestro.ast.ABasicBlockStm;
+import org.intocps.maestro.ast.AVariableDeclaration;
+import org.intocps.maestro.ast.LexIdentifier;
+import org.intocps.maestro.ast.analysis.AnalysisException;
+import org.intocps.maestro.ast.node.*;
+import org.intocps.maestro.framework.fmi2.api.FmiBuilder;
+import org.intocps.maestro.framework.fmi2.api.mabl.scoping.DynamicActiveBuilderScope;
+import org.intocps.maestro.framework.fmi2.api.mabl.scoping.IMablScope;
+import org.intocps.maestro.framework.fmi2.api.mabl.scoping.ScopeFmi2Api;
+import org.intocps.maestro.framework.fmi2.api.mabl.variables.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.intocps.maestro.ast.MableAstFactory.*;
+import static org.intocps.maestro.ast.MableAstFactory.newAIdentifierStateDesignator;
+import static org.intocps.maestro.ast.MableBuilder.newVariable;
+
+public class ExpansionMableApiBuilder extends MablApiBuilder {
+
+    final ScopeFmi2Api rootOfExpandScope;
+
+    /**
+     * Create a MablApiBuilder
+     *
+     * @param settings
+     */
+    public ExpansionMableApiBuilder(MablSettings settings, INode lastNodePriorToBuilderTakeOver) {
+        super(settings);
+
+        var existingScopes2currentRoot = buildExistingScopes(lastNodePriorToBuilderTakeOver);
+
+        rootOfExpandScope = existingScopes2currentRoot.getFirst();
+        rootScope = new ScopeFmi2Api(this, rootOfExpandScope, new ABasicBlockStm());
+
+        mainErrorHandlingScope = rootScope.enterTry();
+        this.dynamicScope = new DynamicActiveBuilderScope(mainErrorHandlingScope.getBody());
+
+        if (settings.fmiErrorHandlingEnabled) {
+            //create new variables
+//            Function<String, IntVariableFmi2Api> f = (str) -> new IntVariableFmi2Api(null, null, null, null, newAIdentifierExp(str));
+            for (FmiStatus s : FmiStatus.values()) {
+                //if not existing then create
+                var match = findDecleration(rootScope, s.name());
+                if (match == null) {
+                    //create the status as it was not found
+                    fmiStatusVariables.put(s.getValue(), this.dynamicScope.getActiveScope().store( this.getNameGenerator().getNameIgnoreCase(s.name()), s.getValue()));
+                } else if (match.getValue() instanceof ALocalVariableStm local) {
+                    //if exists then link to previous declaration
+//                    fmiStatusVariables.put(s, f.apply(local.getDeclaration().getName().getText()));
+                    fmiStatusVariables.put(s.getValue(), new IntVariableFmi2Api(match.getValue(), match.getKey(), this.dynamicScope, null,
+                            newAIdentifierExp(local.getDeclaration().getName().getText())));
+                }
+
+            }
+        }
+
+        String status_varname = "status";
+
+
+        var decl = MablToMablAPI.findDeclaration(lastNodePriorToBuilderTakeOver, null, false, status_varname);
+        if (decl == null) {
+            globalFmiStatus = rootScope.store(status_varname, FmiStatus.FMI_OK.getValue());
+        } else {
+            globalFmiStatus = (IntVariableFmi2Api) createVariableExact(rootScope, newIntType(), null, decl.getName().getText(), true);
+        }
+
+        //lets find the existing loaded instances
+        var declaredAndLoadedAssignments = MablToMablAPI.getAncestors(lastNodePriorToBuilderTakeOver, n -> n instanceof AAssigmentStm)
+                .map(AAssigmentStm.class::cast).filter(n -> n.getExp() instanceof ALoadExp).toList();
+
+        var loadedDefinitions = declaredAndLoadedAssignments.stream()
+                .collect(Collectors.toMap(n -> n, AAssigmentStm::getTarget));
+
+        Function<AAssigmentStm, String> loadedModuleName = n -> ((AStringLiteralExp) (((ALoadExp) n.getExp()).getArgs().get(0))).getValue();
+
+        var c = loadedDefinitions.entrySet().stream()
+                .filter(map -> (!loadedModuleName.apply(map.getKey()).startsWith("FMI")))
+                .collect(Collectors.toMap(map -> loadedModuleName.apply(map.getKey()), map ->
+
+                        new RuntimeModuleVariable(null, new ANameType(new LexIdentifier(loadedModuleName.apply(map.getKey()), null)), rootScope,
+                                getDynamicScope(), this, map.getValue().clone(),
+                                newAIdentifierExp(((AIdentifierStateDesignator) map.getValue()).getName().getText()))));
+        fromExistingSpecInstanceCache.putAll(c);
+
+
+        AVariableDeclaration loggerDecl = MablToMablAPI.findDeclaration(lastNodePriorToBuilderTakeOver, null, false, "logger");
+        if (loggerDecl != null) {
+            this.getMablToMablAPI().createExternalRuntimeLogger();
+        }
+
+
+        //reserve all previously names to avoid clashing with these
+        MablToMablAPI.getPreviouslyUsedNamed(lastNodePriorToBuilderTakeOver).forEach(this.nameGenerator::addUsedIdentifier);
+
+
+        resetDirty();
+
+    }
+
+    @Override
+    protected void initializeGlobalStatusVariables() {
+
+
+    }
+
+    private static PStm findDecleration(SBlockStm block, String identifier) {
+        var declaredStm = block.getBody().stream().filter(ALocalVariableStm.class::isInstance).map(ALocalVariableStm.class::cast)
+                .map(ALocalVariableStm::getDeclaration)
+                .filter(decl -> decl instanceof AVariableDeclaration declVar && declVar.getName().getText().equals(identifier)).findFirst();
+        return declaredStm.map(aVariableDeclaration -> (PStm) aVariableDeclaration.parent()).orElse(null);
+    }
+
+    public static Pair<IMablScope, PStm> findDecleration(FmiBuilder.ScopeElement<PStm> scope, String identifier) {
+        IMablScope declaringScope = (IMablScope) scope;
+        PStm declaredStm = null;
+
+        var scopeDeclaration = scope.getDeclaration();
+        if (scopeDeclaration instanceof SBlockStm block) {
+            declaredStm = findDecleration(block, identifier);
+        } else if (scopeDeclaration instanceof AWhileStm whileStm) {
+            if (whileStm.getBody() instanceof SBlockStm block) {
+                declaredStm = findDecleration(block, identifier);
+            }
+        } else if (scopeDeclaration instanceof ATryStm tryStm) {
+            if (tryStm.getBody() instanceof SBlockStm block) {
+                declaredStm = findDecleration(block, identifier);
+            }
+
+        } else if (scopeDeclaration instanceof AIfStm tryStm) {
+            if (tryStm.getThen() instanceof SBlockStm block) {
+                declaredStm = findDecleration(block, identifier);
+            }
+            if (declaredStm == null) {
+                if (tryStm.getElse() instanceof SBlockStm block) {
+                    declaredStm = findDecleration(block, identifier);
+                }
+            }
+        }
+
+        if (declaredStm == null) {
+            var parent = scope.parent();
+            declaringScope = (IMablScope) parent;
+            if (parent != null) {
+                return findDecleration(parent, identifier);
+            }
+        }
+
+        if (declaredStm != null) {
+            return Pair.of(declaringScope, declaredStm);
+        }
+        return null;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private Variable createVariable(IMablScope scope, PType type, PExp initialValue, String... prefixes) {
+        String name = nameGenerator.getName(prefixes);
+        return createVariableExact(scope, type, initialValue, name, false);
+    }
+
+    private Variable createVariableExact(IMablScope scope, PType type, PExp initialValue, String name, boolean external) {
+        PStm var = newVariable(name, type, initialValue);
+        if (!external) {
+            scope.add(var);
+        }
+        this.externalScope.add(var);
+        if (type instanceof ARealNumericPrimitiveType) {
+            return new DoubleVariableFmi2Api(var, externalScope, dynamicScope, newAIdentifierStateDesignator(name), newAIdentifierExp(name));
+        } else if (type instanceof ABooleanPrimitiveType) {
+            return new BooleanVariableFmi2Api(var, externalScope, dynamicScope, newAIdentifierStateDesignator(name), newAIdentifierExp(name));
+        } else if (type instanceof AIntNumericPrimitiveType) {
+            return new IntVariableFmi2Api(var, externalScope, dynamicScope, newAIdentifierStateDesignator(name), newAIdentifierExp(name));
+        } else if (type instanceof AStringPrimitiveType) {
+            return new StringVariableFmi2Api(var, externalScope, dynamicScope, newAIdentifierStateDesignator(name), newAIdentifierExp(name));
+        }
+
+        return new VariableFmi2Api(var, type, externalScope, dynamicScope, newAIdentifierStateDesignator(name), newAIdentifierExp(name));
+    }
+
+    /**
+     * Returns the scope hierarchy from root to current scope for the node passed as argument
+     *
+     * @param currentNode
+     * @return
+     */
+    private List<ScopeFmi2Api> buildExistingScopes(INode currentNode) {
+        if (currentNode == null) {
+            return new ArrayList<>();
+        }
+        SBlockStm block;
+        List<Pair<SBlockStm, INode>> scope2Node = new ArrayList<>();
+        while (currentNode!=null && (block = currentNode.getAncestor(SBlockStm.class)) != null) {
+            scope2Node.add(Pair.of(block, currentNode));
+            currentNode = block.parent();
+        }
+
+
+        List<ScopeFmi2Api> scopes = new ArrayList<>();
+        IMablScope currentScope = null;
+        for (var pair : scope2Node.reversed()) {
+            scopes.add(new ScopeFmi2Api(this, currentScope, pair.getKey()));
+
+        }
+
+        return scopes;
+    }
+
+
+    @Override
+    public ASimulationSpecificationCompilationUnit build() throws AnalysisException {
+        var noParentScope = new ScopeFmi2Api(this, null, rootScope.getBlock());
+        return internalBuild(noParentScope);
+    }
+}

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/ExpansionMableApiBuilder.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/ExpansionMableApiBuilder.java
@@ -49,7 +49,8 @@ public class ExpansionMableApiBuilder extends MablApiBuilder {
                 var match = findDecleration(rootScope, s.name());
                 if (match == null) {
                     //create the status as it was not found
-                    fmiStatusVariables.put(s.getValue(), this.dynamicScope.getActiveScope().store( this.getNameGenerator().getNameIgnoreCase(s.name()), s.getValue()));
+                    ScopeFmi2Api scope = (ScopeFmi2Api) this.dynamicScope.getActiveScope();
+                    fmiStatusVariables.put(s.getValue(), scope.store(s::name, s.getValue()));
                 } else if (match.getValue() instanceof ALocalVariableStm local) {
                     //if exists then link to previous declaration
 //                    fmiStatusVariables.put(s, f.apply(local.getDeclaration().getName().getText()));

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/FromMaBLToMaBLAPI.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/FromMaBLToMaBLAPI.java
@@ -1,7 +1,9 @@
 package org.intocps.maestro.framework.fmi2.api.mabl;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.intocps.maestro.ast.AVariableDeclaration;
 import org.intocps.maestro.ast.LexIdentifier;
+import org.intocps.maestro.ast.LexLocation;
 import org.intocps.maestro.ast.node.*;
 import org.intocps.maestro.framework.core.FrameworkUnitInfo;
 import org.intocps.maestro.framework.core.IRelation;
@@ -11,6 +13,7 @@ import org.intocps.maestro.framework.fmi2.Fmi2SimulationEnvironment;
 import org.intocps.maestro.framework.fmi2.InstanceInfo;
 import org.intocps.maestro.framework.fmi2.RelationVariable;
 import org.intocps.maestro.framework.fmi2.api.FmiBuilder;
+import org.intocps.maestro.framework.fmi2.api.mabl.scoping.IMablScope;
 import org.intocps.maestro.framework.fmi2.api.mabl.variables.ComponentVariableFmi2Api;
 import org.intocps.maestro.framework.fmi2.api.mabl.variables.FmuVariableFmi2Api;
 import org.intocps.maestro.framework.fmi2.api.mabl.variables.FmuVariableFmi3Api;
@@ -24,12 +27,13 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.intocps.maestro.ast.MableAstFactory.*;
+import static org.intocps.maestro.framework.fmi2.api.mabl.ExpansionMableApiBuilder.findDecleration;
 
 public class FromMaBLToMaBLAPI {
     final static Logger logger = LoggerFactory.getLogger(FromMaBLToMaBLAPI.class);
 
     public static Map.Entry<String, ComponentVariableFmi2Api> getComponentVariableFrom(MablApiBuilder builder, PExp exp,
-            Fmi2SimulationEnvironment env) throws XPathExpressionException, InvocationTargetException, IllegalAccessException {
+                                                                                       Fmi2SimulationEnvironment env) throws XPathExpressionException, InvocationTargetException, IllegalAccessException {
         if (exp instanceof AIdentifierExp) {
             return getComponentVariableFrom(builder, exp, env, ((AIdentifierExp) exp).getName().getText());
         } else {
@@ -38,7 +42,7 @@ public class FromMaBLToMaBLAPI {
     }
 
     public static Map.Entry<String, InstanceVariableFmi3Api> getInstanceVariableFrom(MablApiBuilder builder, PExp exp,
-                                                                                       Fmi2SimulationEnvironment env) throws XPathExpressionException, InvocationTargetException, IllegalAccessException {
+                                                                                     Fmi2SimulationEnvironment env) throws XPathExpressionException, InvocationTargetException, IllegalAccessException {
         if (exp instanceof AIdentifierExp) {
             return getInstanceVariableFrom(builder, exp, env, ((AIdentifierExp) exp).getName().getText());
         } else {
@@ -47,8 +51,8 @@ public class FromMaBLToMaBLAPI {
     }
 
     public static Map.Entry<String, ComponentVariableFmi2Api> getComponentVariableFrom(MablApiBuilder builder, PExp exp,
-            Fmi2SimulationEnvironment env,
-            String environmentComponentName) throws IllegalAccessException, XPathExpressionException, InvocationTargetException {
+                                                                                       Fmi2SimulationEnvironment env,
+                                                                                       String environmentComponentName) throws IllegalAccessException, XPathExpressionException, InvocationTargetException {
         if (exp instanceof AIdentifierExp) {
             String componentName = ((AIdentifierExp) exp).getName().getText();
 
@@ -66,7 +70,8 @@ public class FromMaBLToMaBLAPI {
                 FmuVariableFmi2Api fmu =
                         new FmuVariableFmi2Api(instance.fmuIdentifier, builder, modelDescriptionContext, dummyStm, newANameType("FMI2"),
                                 builder.getDynamicScope().getActiveScope(), builder.getDynamicScope(), null,
-                                new AIdentifierExp(new LexIdentifier(instance.fmuIdentifier.replace("{", "").replace("}", ""), null)));
+                                new AIdentifierExp(new LexLocation("", 0, 0),
+                                        new LexIdentifier(instance.fmuIdentifier.replace("{", "").replace("}", ""), null)));
 
                 ComponentVariableFmi2Api a;
                 if (environmentComponentName == null) {
@@ -94,43 +99,61 @@ public class FromMaBLToMaBLAPI {
         }
     }
 
+//    public Map.Entry<IMablScope, Optional<PStm>> findDeclScopeAndDesignator(IMablScope scope, String name) {
+//        var blockStm = scope.getDeclaration();
+//        if (blockStm instanceof ABasicBlockStm block) {
+//            var declaredStm = block.getBody().reversed().stream()
+//                    .filter(decl -> decl instanceof AVariableDeclaration declVar && declVar.getName().getText().equals(name)).findFirst();
+//            if(declaredStm.isPresent())
+//                return Map.entry(scope,declaredStm);
+//        }
+//        IMablScope parent=        scope.parent().
+//
+//
+//        return null;
+//    }
+
     public static Map.Entry<String, InstanceVariableFmi3Api> getInstanceVariableFrom(MablApiBuilder builder, PExp exp, Fmi2SimulationEnvironment env,
-            String environmentComponentName) throws IllegalAccessException, XPathExpressionException, InvocationTargetException {
+                                                                                     String environmentComponentName) throws IllegalAccessException, XPathExpressionException, InvocationTargetException {
         if (exp instanceof AIdentifierExp) {
             String componentName = ((AIdentifierExp) exp).getName().getText();
 
             FrameworkUnitInfo inst = env.getInstanceByLexName(environmentComponentName);
-            if (inst instanceof InstanceInfo) {
-
-
-                InstanceInfo instance = (InstanceInfo) inst;
+            if (inst instanceof InstanceInfo instance) {
                 ModelDescriptionContext3 modelDescriptionContext = new ModelDescriptionContext3(instance.getModelDescription());
 
-                //This dummy statement is removed later. It ensures that the share variables are added to the root scope.
-                PStm dummyStm = newABlockStm();
-                builder.getDynamicScope().add(dummyStm);
+
+                var fmuScope2Name = findDecleration(builder.getRootScope(), componentName);
+                if (fmuScope2Name == null) {
+                    throw new RuntimeException("FMU declaration not found in scope: " + instance.fmuIdentifier);
+                }
 
                 FmuVariableFmi3Api fmu =
-                        new FmuVariableFmi3Api(instance.fmuIdentifier, builder, modelDescriptionContext, dummyStm, newANameType("FMI3"),
-                                builder.getDynamicScope().getActiveScope(), builder.getDynamicScope(), null,
-                                new AIdentifierExp(new LexIdentifier(instance.fmuIdentifier.replace("{", "").replace("}", ""), null)));
+                        new FmuVariableFmi3Api(instance.fmuIdentifier, builder, modelDescriptionContext, fmuScope2Name.getValue(), newANameType("FMI3"),
+                                fmuScope2Name.getKey(), builder.getDynamicScope(), null,
+                                new AIdentifierExp(new LexLocation("", 0, 0),
+                                        new LexIdentifier(instance.fmuIdentifier.replace("{", "").replace("}", ""), null)));
+
+
+                var scope2Name = findDecleration(builder.getRootScope(), componentName);
+                if (scope2Name == null) {
+                    throw new RuntimeException("Instance declaration not found in scope: " + componentName);
+                }
+                var declaringScope = scope2Name.getLeft();
+                var declaredStm = scope2Name.getRight();
 
                 InstanceVariableFmi3Api a;
                 if (environmentComponentName == null) {
-                    a = new InstanceVariableFmi3Api(dummyStm, fmu, componentName, modelDescriptionContext, builder,
-                            builder.getDynamicScope().getActiveScope(), null, newAIdentifierExp(componentName));
+                    a = new InstanceVariableFmi3Api(declaredStm, fmu, componentName, modelDescriptionContext, builder,
+                            declaringScope, null, newAIdentifierExp(componentName));
                 } else {
-                    a = new InstanceVariableFmi3Api(dummyStm, fmu, componentName, modelDescriptionContext, builder,
-                            builder.getDynamicScope().getActiveScope(), null, newAIdentifierExp(componentName), environmentComponentName);
+                    a = new InstanceVariableFmi3Api(declaredStm, fmu, componentName, modelDescriptionContext, builder,
+                            declaringScope, null, newAIdentifierExp(componentName), environmentComponentName);
                 }
-                List<RelationVariable> variablesToLog = null;
-                if (environmentComponentName == null) {
-                    variablesToLog = env.getVariablesToLog(componentName);
-                } else {
-                    variablesToLog = env.getVariablesToLog(environmentComponentName);
-                }
-                a.setVariablesToLog(variablesToLog.stream().filter(org.intocps.maestro.framework.fmi2.RelationVariable.class::isInstance)
-                        .map(org.intocps.maestro.framework.fmi2.RelationVariable.class::cast).collect(Collectors.toList()));
+
+                var variablesToLog = environmentComponentName == null? env.getVariablesToLog(componentName):env.getVariablesToLog(environmentComponentName);
+
+                a.setVariablesToLog(variablesToLog.stream().filter(Objects::nonNull).collect(Collectors.toList()));
 
                 return Map.entry(componentName, a);
             } else {
@@ -141,8 +164,10 @@ public class FromMaBLToMaBLAPI {
         }
     }
 
+
+
     public static void createBindings(Map<String, ComponentVariableFmi2Api> instances,
-            ISimulationEnvironment env) throws FmiBuilder.Port.PortLinkException {
+                                      ISimulationEnvironment env) throws FmiBuilder.Port.PortLinkException {
         for (Map.Entry<String, ComponentVariableFmi2Api> entry : instances.entrySet()) {
             java.util.Set<? extends IRelation> relations = getRelations(entry, env);
             for (IRelation relation : relations.stream().filter(x -> x.getDirection() == Fmi2SimulationEnvironment.Relation.Direction.OutputToInput &&
@@ -183,11 +208,11 @@ public class FromMaBLToMaBLAPI {
     }
 
     public static void createBindings3(Map<String, InstanceVariableFmi3Api> instances,
-            ISimulationEnvironment env) throws FmiBuilder.Port.PortLinkException {
+                                       ISimulationEnvironment env) throws FmiBuilder.Port.PortLinkException {
         for (Map.Entry<String, InstanceVariableFmi3Api> entry : instances.entrySet()) {
             java.util.Set<? extends IRelation> relations = getRelations3(entry, env);
             for (IRelation relation : relations.stream().filter(x -> x.getDirection() == Fmi2SimulationEnvironment.Relation.Direction.OutputToInput &&
-                    x.getOrigin() == Fmi2SimulationEnvironment.Relation.InternalOrExternal.External).collect(Collectors.toList())) {
+                    x.getOrigin() == Fmi2SimulationEnvironment.Relation.InternalOrExternal.External).toList()) {
 
                 for (var targetVar : relation.getTargets().values()) {
                     String targetName = targetVar.getInstance().getText();
@@ -241,7 +266,7 @@ public class FromMaBLToMaBLAPI {
 
 
     public static Map<String, ComponentVariableFmi2Api> getComponentVariablesFrom(MablApiBuilder builder, PExp exp,
-            Fmi2SimulationEnvironment env) throws IllegalAccessException, XPathExpressionException, InvocationTargetException {
+                                                                                  Fmi2SimulationEnvironment env) throws IllegalAccessException, XPathExpressionException, InvocationTargetException {
         LexIdentifier componentsArrayName = ((AIdentifierExp) exp).getName();
         SBlockStm containingBlock = exp.getAncestor(SBlockStm.class);
         Optional<AVariableDeclaration> componentDeclaration =
@@ -273,7 +298,7 @@ public class FromMaBLToMaBLAPI {
 
 
     public static Map<String, InstanceVariableFmi3Api> getInstanceVariablesFrom(MablApiBuilder builder, PExp exp,
-                                                                                  Fmi2SimulationEnvironment env) throws IllegalAccessException, XPathExpressionException, InvocationTargetException {
+                                                                                Fmi2SimulationEnvironment env) throws IllegalAccessException, XPathExpressionException, InvocationTargetException {
         LexIdentifier componentsArrayName = ((AIdentifierExp) exp).getName();
         SBlockStm containingBlock = exp.getAncestor(SBlockStm.class);
         Optional<AVariableDeclaration> componentDeclaration =

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/LoggerFmi2Api.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/LoggerFmi2Api.java
@@ -1,14 +1,29 @@
 package org.intocps.maestro.framework.fmi2.api.mabl;
 
+import com.fujitsu.vdmj.ast.lex.LexNameToken;
+import org.intocps.maestro.ast.LexLocation;
+import org.intocps.maestro.ast.MableBuilder;
+import org.intocps.maestro.ast.node.AIdentifierExp;
+import org.intocps.maestro.ast.node.AIntLiteralExp;
+import org.intocps.maestro.ast.node.PExp;
 import org.intocps.maestro.ast.node.PStm;
 import org.intocps.maestro.framework.fmi2.api.FmiBuilder;
 import org.intocps.maestro.framework.fmi2.api.mabl.scoping.ScopeFmi2Api;
+
+import java.util.Arrays;
+import java.util.Vector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.intocps.maestro.ast.MableAstFactory.newExpressionStm;
 
 public class LoggerFmi2Api {
 
     final FmiBuilder.RuntimeModule<PStm> module;
 
     final FmiBuilder.RuntimeFunction logFunction;
+
+    final FmiBuilder.RuntimeFunction logFmiCallVRefsFunction;
 
     public LoggerFmi2Api(MablApiBuilder builder, FmiBuilder.RuntimeModule<PStm> module) {
         this.module = module;
@@ -17,6 +32,11 @@ public class LoggerFmi2Api {
                 .addArgument("args", FmiBuilder.RuntimeFunction.FunctionType.Type.Any).useVargs()
                 .setReturnType(FmiBuilder.RuntimeFunction.FunctionType.Type.Void).build();
         module.initialize(logFunction);
+
+        logFmiCallVRefsFunction = builder.getFunctionBuilder().setName("logFmiCallVRefs").addArgument("vr", FmiBuilder.RuntimeFunction.FunctionType.Type.Any).addArgument("nvr", FmiBuilder.RuntimeFunction.FunctionType.Type.Int).addArgument("format", FmiBuilder.RuntimeFunction.FunctionType.Type.String)
+                .addArgument("args", FmiBuilder.RuntimeFunction.FunctionType.Type.Any).useVargs()
+                .setReturnType(FmiBuilder.RuntimeFunction.FunctionType.Type.Void).build();
+        module.initialize(logFmiCallVRefsFunction);
     }
 
     public void log(Level level, String format, Object... args) {
@@ -67,6 +87,16 @@ public class LoggerFmi2Api {
 
     public void error(ScopeFmi2Api scope, String format, Object... args) {
         log(scope, Level.ERROR, format, args);
+    }
+
+    public void logFmiCallVRefs(ScopeFmi2Api scope,PExp vr, PExp nvr, String format, Object... args){
+       // module.call(logFmiCallVRefsFunction,Level.ERROR, vr,nvr,format, args);
+        var arguments = new Vector<>(Arrays.asList(args));
+//        arguments.addFirst(Level.ERROR);
+        arguments.addFirst(format);
+        PStm stm = newExpressionStm(MableBuilder.call(module.getExp().clone(),logFmiCallVRefsFunction.getName(),
+                Stream.concat(Stream.of(new AIntLiteralExp(new LexLocation("",0,0),Level.ERROR.level),vr,nvr), BuilderUtil.toExp(arguments.toArray()).stream()).map(PExp::clone).collect(Collectors.toList())));
+        scope.add(stm);
     }
 
 

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/MablApiBuilder.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/MablApiBuilder.java
@@ -101,7 +101,7 @@ public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecification
 
     private IntVariableFmi2Api getFmiStatusConstant_aux(FmiStatusInterface status) {
         if (!this.fmiStatusVariables.containsKey(status.getValue())) {
-            IntVariableFmi2Api var = rootScope.store(status.getName(), status.getValue());
+            IntVariableFmi2Api var = rootScope.store(status::getName, status.getValue());
             rootScope.addAfterOrTop(null, var.getDeclaringStm());
             fmiStatusVariables.put(status.getValue(), var);
         }

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/MablApiBuilder.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/MablApiBuilder.java
@@ -30,15 +30,15 @@ import static org.intocps.maestro.ast.MableBuilder.newVariable;
 
 public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecificationCompilationUnit, PExp, MablApiBuilder.MablSettings> {
 
-    static ScopeFmi2Api rootScope;
+    ScopeFmi2Api rootScope;
     final ScopeFmi2Api externalScope = new ScopeFmi2Api(this);
-    final DynamicActiveBuilderScope dynamicScope;
+    protected DynamicActiveBuilderScope dynamicScope;
     final TagNameGenerator nameGenerator = new TagNameGenerator();
-    final TryMaBlScope mainErrorHandlingScope;
-    private final IntVariableFmi2Api globalFmiStatus;
+    protected TryMaBlScope mainErrorHandlingScope;
+    protected IntVariableFmi2Api globalFmiStatus;
     private final MablToMablAPI mablToMablAPI;
     private final MablSettings settings;
-    private final Map<FmiStatusInterface, IntVariableFmi2Api> fmiStatusVariables;
+    protected final Map<Integer, IntVariableFmi2Api> fmiStatusVariables = new HashMap<>();
     private final Set<String> externalLoadedModuleIdentifier = new HashSet<>();
     int dynamicScopeInitialSize;
     Set<String> importedModules = new TreeSet<>();
@@ -48,101 +48,32 @@ public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecification
     private MathBuilderFmi2Api mathBuilderApi;
 
     public MablApiBuilder() {
-        this(new MablSettings(), null);
+        this(new MablSettings());
     }
 
 
     public MablApiBuilder(MablSettings settings) {
-        this(settings, null);
-    }
-
-    /**
-     * Create a MablApiBuilder
-     *
-     * @param settings
-     */
-    public MablApiBuilder(MablSettings settings, INode lastNodePriorToBuilderTakeOver) {
-
-        boolean createdFromExistingSpec = lastNodePriorToBuilderTakeOver != null;
-
 
         this.settings = settings;
         rootScope = new ScopeFmi2Api(this);
 
-        fmiStatusVariables = new HashMap<>();
-        if (settings.fmiErrorHandlingEnabled) {
-            if (createdFromExistingSpec) {
-                //create new variables
-                Function<String, IntVariableFmi2Api> f = (str) -> new IntVariableFmi2Api(null, null, null, null, newAIdentifierExp(str));
-                for (FmiStatus s : FmiStatus.values()) {
-                    //if not existing then create
-                    AVariableDeclaration decl = MablToMablAPI.findDeclaration(lastNodePriorToBuilderTakeOver, null, false, s.name());
-                    if (decl == null) {
-                        //create the status as it was not found
-                        fmiStatusVariables.put(s, rootScope.store(() -> this.getNameGenerator().getNameIgnoreCase(s.name()), s.getValue()));
-                    } else {
-                        //if exists then link to previous declaration
-                        fmiStatusVariables.put(s, f.apply(decl.getName().getText()));
-                    }
-                }
-            }
-        }
 
-        String status_varname = "status";
-
-        if (createdFromExistingSpec) {
-
-            AVariableDeclaration decl = MablToMablAPI.findDeclaration(lastNodePriorToBuilderTakeOver, null, false, "global_execution_continue");
-
-            decl = MablToMablAPI.findDeclaration(lastNodePriorToBuilderTakeOver, null, false, status_varname);
-            if (decl == null) {
-                globalFmiStatus = rootScope.store(status_varname, FmiStatus.FMI_OK.getValue());
-            } else {
-                globalFmiStatus = (IntVariableFmi2Api) createVariableExact(rootScope, newIntType(), null, decl.getName().getText(), true);
-            }
-
-            //lets find the existing loaded instances
-            @NotNull List<AAssigmentStm> declaredAndLoadedAssignments = MablToMablAPI.getAncestors(lastNodePriorToBuilderTakeOver,
-                    n -> n instanceof AAssigmentStm).map(AAssigmentStm.class::cast).filter(n -> n.getExp() instanceof ALoadExp).collect(Collectors.toList());
-
-            @NotNull Map<AAssigmentStm, PStateDesignator> loadedDefinitions = declaredAndLoadedAssignments.stream()
-                    .collect(Collectors.toMap(n -> n, AAssigmentStm::getTarget));
-
-            Function<AAssigmentStm, String> loadedModuleName = n -> ((AStringLiteralExp) (((ALoadExp) n.getExp()).getArgs().get(0))).getValue();
-
-            @NotNull Map<String, RuntimeModuleVariable> c = loadedDefinitions.entrySet().stream()
-                    .filter(map -> (!loadedModuleName.apply(map.getKey()).startsWith("FMI")))
-                    .collect(Collectors.toMap(map -> loadedModuleName.apply(map.getKey()), map ->
-
-                            new RuntimeModuleVariable(null, new ANameType(new LexIdentifier(loadedModuleName.apply(map.getKey()), null)),
-                                   rootScope, getDynamicScope(), this, map.getValue().clone(),
-                                    newAIdentifierExp(((AIdentifierStateDesignator)map.getValue()).getName().getText()))
-                    ));
-            fromExistingSpecInstanceCache.putAll(c);
-
-        } else {
-
-            globalFmiStatus = rootScope.store(status_varname, FmiStatus.FMI_OK.getValue());
-        }
+        initializeGlobalStatusVariables();
 
         mainErrorHandlingScope = rootScope.enterTry();
         this.dynamicScope = new DynamicActiveBuilderScope(mainErrorHandlingScope.getBody());
         this.mablToMablAPI = new MablToMablAPI(this);
 
-        if (createdFromExistingSpec) {
-            AVariableDeclaration decl = MablToMablAPI.findDeclaration(lastNodePriorToBuilderTakeOver, null, false, "logger");
-            if (decl != null) {
-                this.getMablToMablAPI().createExternalRuntimeLogger();
-            }
-
-            //reserve all previously names to avoid clashing with these
-            MablToMablAPI.getPreviouslyUsedNamed(lastNodePriorToBuilderTakeOver).forEach(this.nameGenerator::addUsedIdentifier);
-        }
-
-
         resetDirty();
-
     }
+
+    protected void initializeGlobalStatusVariables() {
+
+        String status_varname = "status";
+
+        globalFmiStatus = rootScope.store(status_varname, FmiStatus.FMI_OK.getValue());
+    }
+
 
     @Override
     public boolean isDirty() {
@@ -170,12 +101,12 @@ public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecification
     }
 
     private IntVariableFmi2Api getFmiStatusConstant_aux(FmiStatusInterface status) {
-        if (!this.fmiStatusVariables.containsKey(status)) {
+        if (!this.fmiStatusVariables.containsKey(status.getValue())) {
             IntVariableFmi2Api var = rootScope.store(status.getName(), status.getValue());
             rootScope.addAfterOrTop(null, var.getDeclaringStm());
-            fmiStatusVariables.put(status, var);
+            fmiStatusVariables.put(status.getValue(), var);
         }
-        return this.fmiStatusVariables.get(status);
+        return this.fmiStatusVariables.get(status.getValue());
     }
 
     public IntVariableFmi2Api getFmiStatusConstant(FmiStatus status) {
@@ -194,30 +125,6 @@ public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecification
         return globalFmiStatus;
     }
 
-    @SuppressWarnings("rawtypes")
-    private Variable createVariable(IMablScope scope, PType type, PExp initialValue, String... prefixes) {
-        String name = nameGenerator.getName(prefixes);
-        return createVariableExact(scope, type, initialValue, name, false);
-    }
-
-    private Variable createVariableExact(IMablScope scope, PType type, PExp initialValue, String name, boolean external) {
-        PStm var = newVariable(name, type, initialValue);
-        if (!external) {
-            scope.add(var);
-        }
-        this.externalScope.add(var);
-        if (type instanceof ARealNumericPrimitiveType) {
-            return new DoubleVariableFmi2Api(var, externalScope, dynamicScope, newAIdentifierStateDesignator(name), newAIdentifierExp(name));
-        } else if (type instanceof ABooleanPrimitiveType) {
-            return new BooleanVariableFmi2Api(var, externalScope, dynamicScope, newAIdentifierStateDesignator(name), newAIdentifierExp(name));
-        } else if (type instanceof AIntNumericPrimitiveType) {
-            return new IntVariableFmi2Api(var, externalScope, dynamicScope, newAIdentifierStateDesignator(name), newAIdentifierExp(name));
-        } else if (type instanceof AStringPrimitiveType) {
-            return new StringVariableFmi2Api(var, externalScope, dynamicScope, newAIdentifierStateDesignator(name), newAIdentifierExp(name));
-        }
-
-        return new VariableFmi2Api(var, type, externalScope, dynamicScope, newAIdentifierStateDesignator(name), newAIdentifierExp(name));
-    }
 
     public TagNameGenerator getNameGenerator() {
         return nameGenerator;
@@ -409,7 +316,11 @@ public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecification
 
     @Override
     public ASimulationSpecificationCompilationUnit build() throws AnalysisException {
-        SBlockStm block = rootScope.getBlock().clone();
+        return internalBuild(rootScope);
+    }
+
+    public ASimulationSpecificationCompilationUnit internalBuild(ScopeFmi2Api scope) throws AnalysisException {
+        SBlockStm block = scope.getBlock().clone();
 
         //        SBlockStm errorHandingBlock = this.getErrorHandlingBlock(block);
 
@@ -582,9 +493,9 @@ public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecification
 
     <T> T load(String moduleType, Function<FmiBuilder.RuntimeModule<PStm>, T> creator, Object... args) {
 
-        if(fromExistingSpecInstanceCache.containsKey(moduleType)&& !instanceCache.containsKey(moduleType)) {
+        if (fromExistingSpecInstanceCache.containsKey(moduleType) && !instanceCache.containsKey(moduleType)) {
             //lets convert the instance
-            instanceCache.put(moduleType,creator.apply(fromExistingSpecInstanceCache.get(moduleType)));
+            instanceCache.put(moduleType, creator.apply(fromExistingSpecInstanceCache.get(moduleType)));
         }
 
         if (instanceCache.containsKey(moduleType)) {

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/MablApiBuilder.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/MablApiBuilder.java
@@ -28,6 +28,7 @@ import static org.intocps.maestro.ast.MableAstFactory.*;
 import static org.intocps.maestro.ast.MableBuilder.newVariable;
 
 
+@SuppressWarnings("deprecation")
 public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecificationCompilationUnit, PExp, MablApiBuilder.MablSettings> {
 
     ScopeFmi2Api rootScope;
@@ -45,7 +46,6 @@ public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecification
     List<RuntimeModuleVariable> loadedModules = new Vector<>();
     Map<String, Object> instanceCache = new HashMap<>();
     Map<String, RuntimeModuleVariable> fromExistingSpecInstanceCache = new HashMap<>();
-    private MathBuilderFmi2Api mathBuilderApi;
 
     public MablApiBuilder() {
         this(new MablSettings());
@@ -56,7 +56,6 @@ public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecification
 
         this.settings = settings;
         rootScope = new ScopeFmi2Api(this);
-
 
         initializeGlobalStatusVariables();
 
@@ -131,13 +130,7 @@ public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecification
     }
 
     public MathBuilderFmi2Api getMathBuilder() {
-        if (this.mathBuilderApi == null) {
-            RuntimeModuleVariable runtimeModule = this.loadRuntimeModule("Math");
-
-            this.mathBuilderApi = new MathBuilderFmi2Api(this.dynamicScope, this, runtimeModule.getReferenceExp());
-        }
-        return this.mathBuilderApi;
-
+        return load("Math", runtime -> new MathBuilderFmi2Api(this.dynamicScope, this, runtime.getExp()));
     }
 
     @Override
@@ -150,6 +143,7 @@ public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecification
         return this.dynamicScope;
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public <V, T> Variable<T, V> getCurrentLinkedValue(Port port) {
         PortFmi2Api mp = (PortFmi2Api) port;
@@ -196,6 +190,7 @@ public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecification
         return new BooleanVariableFmi2Api(null, rootScope, this.dynamicScope, t.getLeft(), t.getRight());
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public FmuVariableFmi2Api getFmuVariableFrom(PExp exp) {
         return null;
@@ -420,11 +415,9 @@ public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecification
             @Override
             public void caseABasicBlockStm(ABasicBlockStm node) throws AnalysisException {
                 if (node.getBody().isEmpty()) {
-                    if (node.parent() instanceof SBlockStm) {
-                        SBlockStm pb = (SBlockStm) node.parent();
+                    if (node.parent() instanceof SBlockStm pb) {
                         pb.getBody().remove(node);
-                    } else if (node.parent() instanceof AIfStm) {
-                        AIfStm ifStm = (AIfStm) node.parent();
+                    } else if (node.parent() instanceof AIfStm ifStm) {
 
                         if (ifStm.getElse() == node) {
                             ifStm.setElse(null);
@@ -435,7 +428,6 @@ public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecification
                 }
             }
         });
-
     }
 
     public FunctionBuilder getFunctionBuilder() {
@@ -593,6 +585,7 @@ public class MablApiBuilder implements FmiBuilder<PStm, ASimulationSpecification
          * Automatically perform FMI2ErrorHandling
          */
         public boolean fmiErrorHandlingEnabled = true;
+        public boolean fmiErrorHandlingDetailEnabled = false;
         /**
          * Automatically retrieves and sets derivatives if possible
          */

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/MablToMablAPI.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/MablToMablAPI.java
@@ -2,6 +2,7 @@ package org.intocps.maestro.framework.fmi2.api.mabl;
 
 import org.intocps.maestro.ast.AVariableDeclaration;
 import org.intocps.maestro.ast.LexIdentifier;
+import org.intocps.maestro.ast.LexLocation;
 import org.intocps.maestro.ast.node.*;
 import org.intocps.maestro.framework.fmi2.api.FmiBuilder;
 import org.intocps.maestro.framework.fmi2.api.mabl.variables.RuntimeModuleVariable;
@@ -192,7 +193,7 @@ public class MablToMablAPI {
     public MathBuilderFmi2Api getMathBuilder() {
         if (this.mathBuilderFmi2Api == null) {
             this.mathBuilderFmi2Api = new MathBuilderFmi2Api(this.mablApiBuilder.dynamicScope, this.mablApiBuilder,
-                    new AIdentifierExp(new LexIdentifier("math", null)));
+                    new AIdentifierExp(new LexLocation("",0,0),new LexIdentifier("math", null)));
         }
         return this.mathBuilderFmi2Api;
     }

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/MathBuilderFmi2Api.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/MathBuilderFmi2Api.java
@@ -55,7 +55,7 @@ public class MathBuilderFmi2Api {
     }
 
 
-    public DoubleVariableFmi2Api minRealFromArray(ArrayVariableFmi2Api<Double> array) {
+    public DoubleVariableFmi2Api minRealFromArray(ArrayVariableFmi2Api array) {
         String variableName = dynamicScope.getName("minVal");
         PStm stm = newALocalVariableStm(newAVariableDeclaration(newAIdentifier(variableName), newARealNumericPrimitiveType(), newAExpInitializer(
                 newACallExp(this.referenceExp.clone(), newAIdentifier(FUNCTION_MINREALFROMARRAY), Collections.singletonList(array.getExp())))));

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/PortFmi3Api.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/PortFmi3Api.java
@@ -2,18 +2,31 @@ package org.intocps.maestro.framework.fmi2.api.mabl;
 
 import org.intocps.maestro.ast.LexIdentifier;
 import org.intocps.maestro.ast.node.*;
-import org.intocps.maestro.fmi.fmi3.Fmi3Causality;
-import org.intocps.maestro.fmi.fmi3.Fmi3ModelDescription;
+import org.intocps.maestro.fmi.fmi3.*;
 import org.intocps.maestro.framework.fmi2.api.FmiBuilder;
 import org.intocps.maestro.framework.fmi2.api.mabl.variables.InstanceVariableFmi3Api;
 import org.intocps.maestro.framework.fmi2.api.mabl.variables.VariableFmi2Api;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 import static org.intocps.maestro.ast.MableAstFactory.*;
 
 public class PortFmi3Api implements FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm> {
+
+    public static class PortFilters {
+
+        public static final Predicate<FmiBuilder.Port> isClock = p -> p instanceof PortFmi3Api && ((PortFmi3Api) p).scalarVariable.getVariable()
+                .getTypeIdentifier() == Fmi3TypeEnum.ClockType;
+        public static final Predicate<PortFmi3Api> isCausalityOutput = p -> p.scalarVariable.getVariable().getCausality() == Fmi3Causality.Output;
+        public static final Predicate<PortFmi3Api> isCausalityInput = p -> p.scalarVariable.getVariable().getCausality() == Fmi3Causality.Input;
+        public static final Predicate<FmiBuilder.Port> isClockedVariable = p -> p instanceof PortFmi3Api && (((PortFmi3Api) p).scalarVariable.getVariable()
+                .getClocks() != null && !((PortFmi3Api) p).scalarVariable.getVariable().getClocks().isEmpty());
+
+        public static final Predicate<FmiBuilder.Port> isClockTimeBased = p -> isClock.test(
+                p) && ((ClockVariable) ((PortFmi3Api) p).scalarVariable.getVariable()).getInterval() != Fmi3ClockInterval.Triggered;
+    }
 
     public final InstanceVariableFmi3Api aMablFmi3InstanceAPI;
     public final Fmi3ModelDescription.Fmi3ScalarVariable scalarVariable;
@@ -73,7 +86,7 @@ public class PortFmi3Api implements FmiBuilder.Port<Fmi3ModelDescription.Fmi3Sca
             case Float64Type:
                 return new ARealNumericPrimitiveType();
             case Float32Type:
-            case ClockType:
+
                 return new AFloatNumericPrimitiveType();
             case Int8Type:
             case UInt8Type:
@@ -89,6 +102,7 @@ public class PortFmi3Api implements FmiBuilder.Port<Fmi3ModelDescription.Fmi3Sca
             case EnumerationType:
                 return new ALongNumericPrimitiveType();
             case BooleanType:
+            case ClockType:
                 return newBoleanType();
             case StringType:
                 return newStringType();

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/PortFmi3Api.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/PortFmi3Api.java
@@ -26,6 +26,8 @@ public class PortFmi3Api implements FmiBuilder.Port<Fmi3ModelDescription.Fmi3Sca
 
         public static final Predicate<FmiBuilder.Port> isClockTimeBased = p -> isClock.test(
                 p) && ((ClockVariable) ((PortFmi3Api) p).scalarVariable.getVariable()).getInterval() != Fmi3ClockInterval.Triggered;
+        public static final Predicate<FmiBuilder.Port> isClockTriggered = p -> isClock.test(
+                p) && ((ClockVariable) ((PortFmi3Api) p).scalarVariable.getVariable()).getInterval() == Fmi3ClockInterval.Triggered;
     }
 
     public final InstanceVariableFmi3Api aMablFmi3InstanceAPI;

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/scoping/ScopeFmi2Api.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/scoping/ScopeFmi2Api.java
@@ -1,9 +1,6 @@
 package org.intocps.maestro.framework.fmi2.api.mabl.scoping;
 
-import org.intocps.maestro.ast.ABasicBlockStm;
-import org.intocps.maestro.ast.AParallelBlockStm;
-import org.intocps.maestro.ast.AVariableDeclaration;
-import org.intocps.maestro.ast.MableAstFactory;
+import org.intocps.maestro.ast.*;
 import org.intocps.maestro.ast.node.*;
 import org.intocps.maestro.fmi.Fmi2ModelDescription;
 

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/scoping/ScopeFmi2Api.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/scoping/ScopeFmi2Api.java
@@ -635,7 +635,7 @@ public class ScopeFmi2Api implements IMablScope, FmiBuilder.WhileScope<PStm> {
 
         List<AStringLiteralExp> strings = new ArrayList<>();
         if (names != null) {
-            strings = Arrays.stream(names).map(s -> new AStringLiteralExp(s)).collect(Collectors.toList());
+            strings = Arrays.stream(names).map(s -> new AStringLiteralExp(new LexLocation("",0,0),s)).collect(Collectors.toList());
         }
 
         add(new ATransferStm(strings));
@@ -646,7 +646,7 @@ public class ScopeFmi2Api implements IMablScope, FmiBuilder.WhileScope<PStm> {
 
         List<AStringLiteralExp> strings = new ArrayList<>();
         if (names != null) {
-            strings = Arrays.stream(names).map(s -> new AStringLiteralExp(s)).collect(Collectors.toList());
+            strings = Arrays.stream(names).map(s -> new AStringLiteralExp(new LexLocation("",0,0),s)).collect(Collectors.toList());
         }
 
         add(new ATransferAsStm(strings));

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/Buffers.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/Buffers.java
@@ -3,7 +3,6 @@ package org.intocps.maestro.framework.fmi2.api.mabl.variables;
 import org.intocps.maestro.ast.node.AIdentifierExp;
 import org.intocps.maestro.ast.node.PStm;
 import org.intocps.maestro.ast.node.PType;
-import org.intocps.maestro.fmi.fmi3.Fmi3TypeEnum;
 import org.intocps.maestro.framework.fmi2.api.mabl.MablApiBuilder;
 import org.intocps.maestro.framework.fmi2.api.mabl.scoping.IMablScope;
 import org.intocps.maestro.framework.fmi2.api.mabl.scoping.ScopeFmi2Api;

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/InstanceClocksFmi3.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/InstanceClocksFmi3.java
@@ -77,6 +77,10 @@ public class InstanceClocksFmi3 {
         this.clocks = instance.getPorts().stream().filter(isClockTimeBased).filter(isCausalityInput).toList();
     }
 
+    public void deactivate(PortFmi3Api clock) {
+        getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Triggered)).setValue(DoubleExpressionValue.of(FALSE));
+    }
+
     enum ClockInfo {
         Shift(0),
         Interval(1),

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/InstanceClocksFmi3.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/InstanceClocksFmi3.java
@@ -1,0 +1,174 @@
+package org.intocps.maestro.framework.fmi2.api.mabl.variables;
+
+import org.intocps.maestro.ast.node.*;
+import org.intocps.maestro.fmi.fmi3.Fmi3ModelDescription;
+import org.intocps.maestro.framework.fmi2.api.FmiBuilder;
+import org.intocps.maestro.framework.fmi2.api.mabl.MablApiBuilder;
+import org.intocps.maestro.framework.fmi2.api.mabl.PortFmi3Api;
+import org.intocps.maestro.framework.fmi2.api.mabl.scoping.IMablScope;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.intocps.maestro.ast.MableAstFactory.*;
+import static org.intocps.maestro.ast.MableBuilder.call;
+import static org.intocps.maestro.framework.fmi2.api.mabl.PortFmi3Api.PortFilters.*;
+
+public class InstanceClocksFmi3 {
+
+    private final InstanceVariableFmi3Api owner;
+    private final List<PortFmi3Api> clocks;
+    private final MablApiBuilder builder;
+
+    /**
+     * Data stored in the format:
+     * array[clockindex] = shift
+     * array[clockindex+1] = interval
+     */
+    ArrayVariableFmi2Api<DoubleVariableFmi2Api> timingDataStorage;
+
+    ArrayVariableFmi2Api<DoubleVariableFmi2Api> intervalBuffer = null;
+    ArrayVariableFmi2Api<IntVariableFmi2Api> intervalQualifierBuffer = null;
+    ArrayVariableFmi2Api<DoubleVariableFmi2Api> shiftBuffer = null;
+
+
+    public ArrayVariableFmi2Api<IntVariableFmi2Api> getIntervalQualifierBuffer() {
+
+        if (this.intervalQualifierBuffer == null) {
+            final int length = this.clocks.size();
+            final PType type = new AIntNumericPrimitiveType();
+            intervalQualifierBuffer = createDataArray(length, "clocks_timing_interval_qualifier_buffer", type);
+        }
+        return this.intervalQualifierBuffer;
+    }
+
+    public ArrayVariableFmi2Api<DoubleVariableFmi2Api> getIntervalBuffer() {
+
+        if (this.intervalBuffer == null) {
+            final int length = this.clocks.size();
+            final PType type = new ARealNumericPrimitiveType();
+            intervalBuffer = createDataArray(length, "clocks_timing_interval_buffer", type);
+        }
+        return this.intervalBuffer;
+    }
+
+    public ArrayVariableFmi2Api<DoubleVariableFmi2Api> getShiftBuffer() {
+
+        if (this.shiftBuffer == null) {
+            final int length = this.clocks.size();
+            final PType type = new ARealNumericPrimitiveType();
+            shiftBuffer = createDataArray(length, "clocks_timing_shift_buffer", type);
+        }
+        return this.shiftBuffer;
+    }
+
+
+    public InstanceClocksFmi3(MablApiBuilder builder, InstanceVariableFmi3Api instance) {
+        this.owner = instance;
+
+        this.builder = builder;
+        this.clocks = instance.getPorts().stream().filter(isClockTimeBased).filter(isCausalityInput).toList();
+    }
+
+    enum ClockInfo {
+        Shift,
+        Interval
+    }
+
+    private int getClockIndex(PortFmi3Api clock, ClockInfo type) {
+        switch (type) {
+            case Shift -> {
+                return this.clocks.indexOf(clock) * 2 + 1;
+            }
+            case Interval -> {
+                return this.clocks.indexOf(clock) * 2;
+            }
+        }
+        throw new RuntimeException("unknown clock info type: " + type);
+    }
+
+    public void storeInterval(FmiBuilder.Scope<PStm> scope, PortFmi3Api clock, PExp interval) {
+        scope
+                .add(newAAssignmentStm(getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Interval)).getDesignator(), interval));
+    }
+
+    public PExp getInterval(PortFmi3Api clock) {
+        return getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Interval)).getReferenceExp();
+    }
+
+    public void storeShift(FmiBuilder.Scope<PStm> scope, PortFmi3Api clock, PExp shift) {
+        scope
+                .add(newAAssignmentStm(getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Shift)).getDesignator(), shift));
+    }
+
+    public PExp getShift(PortFmi3Api clock) {
+        return getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Shift)).getReferenceExp();
+    }
+
+    private ArrayVariableFmi2Api<DoubleVariableFmi2Api> getClockTimingVar() {
+
+        if (this.timingDataStorage == null) {
+            final int length = this.clocks.size() * 2;
+            final PType type = new ARealNumericPrimitiveType();
+            timingDataStorage = createDataArray(length, "clocks_timing_data", type);
+        }
+        return this.timingDataStorage;
+    }
+
+    private <C extends VariableFmi2Api> ArrayVariableFmi2Api<C> createDataArray(int length, String name, PType type) {
+
+        String ioBufName = builder.getNameGenerator().getName(this.owner.getName(), name);
+
+        PStm var = newALocalVariableStm(newAVariableDeclaration(newAIdentifier(ioBufName), type, length, null));
+
+        this.owner.getDeclaredScope().addAfter(this.owner.getDeclaringStm(), var);
+
+        List<VariableFmi2Api> items = IntStream.range(0, length)
+                .mapToObj(i -> new VariableFmi2Api<>(var, type, this.owner.getDeclaredScope(), builder.getDynamicScope(),
+                        newAArayStateDesignator(newAIdentifierStateDesignator(newAIdentifier(ioBufName)), newAIntLiteralExp(i)),
+                        newAArrayIndexExp(newAIdentifierExp(ioBufName), Collections.singletonList(newAIntLiteralExp(i))))).collect(Collectors.toList());
+
+        return new ArrayVariableFmi2Api(var, type, this.owner.getDeclaredScope(), builder.getDynamicScope(),
+                newAIdentifierStateDesignator(newAIdentifier(ioBufName)),
+                newAIdentifierExp(ioBufName), items.stream().collect(Collectors.toList()));
+    }
+
+    public void updateClockIntervals(FmiBuilder.Scope<PStm> scope, ArrayVariableFmi2Api<Object> vrefBuf,
+                                     FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm>... ports) {
+
+        List<PortFmi3Api> selectedPorts;
+        if (ports == null || ports.length == 0) {
+            return;// Map.of();
+        } else {
+            selectedPorts = Arrays.stream(ports).map(PortFmi3Api.class::cast).filter(isClock).filter(isCausalityInput).toList();
+        }
+
+        for (int i = 0; i < selectedPorts.size(); i++) {
+            PortFmi3Api p = selectedPorts.get(i);
+            PStateDesignator designator = vrefBuf.items().get(i).getDesignator().clone();
+            scope.add(newAAssignmentStm(designator, newAIntLiteralExp(p.getPortReferenceValue().intValue())));
+        }
+
+
+        var intervalBuf = getIntervalBuffer();
+        var qualifierBuf = getIntervalQualifierBuffer();
+
+
+//        int getIntervalDecimal(uint valueReferences[], int nValueReferences, real intervals[],
+//        int qualifiers[]);
+
+        List<PExp> args = new ArrayList<>(
+                List.of(vrefBuf.getReferenceExp().clone(), newAUIntLiteralExp((long) selectedPorts.size()), newARefExp(intervalBuf.getReferenceExp().clone()),
+                        newARefExp(qualifierBuf.getReferenceExp().clone())));
+        AAssigmentStm stm = newAAssignmentStm(((IMablScope) scope).getFmiStatusVariable().getDesignator().clone(),
+                call(this.owner.getReferenceExp().clone(), "getIntervalDecimal", args));
+        scope.add(stm);
+
+           this.owner. handleError(scope, new InstanceVariableFmi3Api.CallContext("getIntervalDecimal", args));
+
+        for (short i = 0; i < selectedPorts.size(); i++) {
+            this.storeInterval(scope, selectedPorts.get(i), intervalBuf.items().get(i).getReferenceExp().clone());
+        }
+    }
+}

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/InstanceClocksFmi3.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/InstanceClocksFmi3.java
@@ -1,22 +1,28 @@
 package org.intocps.maestro.framework.fmi2.api.mabl.variables;
 
+import org.intocps.maestro.ast.LexIdentifier;
 import org.intocps.maestro.ast.node.*;
 import org.intocps.maestro.fmi.fmi3.Fmi3ModelDescription;
 import org.intocps.maestro.framework.fmi2.api.FmiBuilder;
-import org.intocps.maestro.framework.fmi2.api.mabl.MablApiBuilder;
-import org.intocps.maestro.framework.fmi2.api.mabl.PortFmi3Api;
+import org.intocps.maestro.framework.fmi2.api.mabl.*;
 import org.intocps.maestro.framework.fmi2.api.mabl.scoping.IMablScope;
+import org.intocps.maestro.framework.fmi2.api.mabl.values.DoubleExpressionValue;
+import org.intocps.maestro.framework.fmi2.api.mabl.values.IntExpressionValue;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.intocps.maestro.ast.MableAstFactory.*;
 import static org.intocps.maestro.ast.MableBuilder.call;
 import static org.intocps.maestro.framework.fmi2.api.mabl.PortFmi3Api.PortFilters.*;
 
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class InstanceClocksFmi3 {
-
+    static final double FALSE = 0.0;
+    static final double TRUE = 1.0;
     private final InstanceVariableFmi3Api owner;
     private final List<PortFmi3Api> clocks;
     private final MablApiBuilder builder;
@@ -72,20 +78,82 @@ public class InstanceClocksFmi3 {
     }
 
     enum ClockInfo {
-        Shift,
-        Interval
+        Shift(0),
+        Interval(1),
+        Ticked(2),
+        Triggered(3),
+        LastTickTime(4);
+        final int value;
+
+        ClockInfo(int value) {
+            this.value = value;
+        }
+    }
+
+    public VariableFmi2Api getClockTriggeredState(PortFmi3Api clock) {
+        return getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Triggered));
+    }
+
+    public PredicateFmi2Api check(FmiBuilder.Scope<PStm> scope, DoubleExpressionValue time, PortFmi3Api clock) {
+
+        var lastTickTime = getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.LastTickTime));
+        var ticked = getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Ticked));
+        var shift = getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Shift));
+        var interval = getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Interval));
+        var triggered = getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Triggered));
+
+        var ifTicked = scope.enterIf(shift.toMath().greaterEqualTo(IntExpressionValue.of(0)).and(ticked.toMath().equalTo(DoubleExpressionValue.of(FALSE))));
+        {
+            /* the clock never ticked before*/
+            var ifTriggered = scope.enterIf(time.greaterEqualTo(shift.toMath()));
+            triggered.setValue(DoubleExpressionValue.of(TRUE));
+            lastTickTime.setValue(time);
+            ticked.setValue(DoubleExpressionValue.of(TRUE));//we will never come back
+//            ifTriggered.enterElse();
+//            triggered.setValue(DoubleExpressionValue.of(FALSE));
+            ifTicked.leave();
+        }
+        ifTicked.enterElse();
+        {
+            /* the clock have ticked before so we check for interval on time*/
+            var ifTriggered = scope.enterIf(time.greaterEqualTo(lastTickTime.toMath().addition(interval.toMath())));
+            triggered.setValue(DoubleExpressionValue.of(TRUE));
+            lastTickTime.setValue(time);
+            ifTriggered.enterElse();
+            triggered.setValue(DoubleExpressionValue.of(FALSE));
+            ifTriggered.leave();
+        }
+        ifTicked.leave();
+        return triggered.toMath().equalTo(DoubleExpressionValue.of(TRUE));
+    }
+
+    public DoubleVariableFmi2Api getTimeToTick(DoubleExpressionValue now, PortFmi3Api clock) {
+        var lastTickTime = getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.LastTickTime));
+        var ticked = getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Ticked));
+        var shift = getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Shift));
+        var interval = getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Interval));
+        var scope = builder.getDynamicScope();
+
+        NumericExpressionValueFmi2Api tickTime = lastTickTime.toMath().addition(interval.toMath());
+        builder.getLogger().debug("Interval %f", getInterval(clock));
+        var vd = new DoubleVariableFmi2Api(null, null, null, null, tickTime.subtraction(now).getExp());
+        builder.getLogger().debug("Time diff %f", vd);
+//        var v = new DoubleVariableFmi2Api(null, null, null, null, tickTime.subtraction(now).getExp());
+        var timeToTickVar = scope.store("time2Tick", vd);
+        var ifTicked = scope.enterIf(ticked.toMath().equalTo(DoubleExpressionValue.of(FALSE)));
+        {
+            var v1 = new DoubleVariableFmi2Api(null, null, null, null, now.subtraction(lastTickTime.toMath()).addition(shift.toMath()).getExp());
+            // timeToTickVar.setValue(v1);
+
+
+        }
+
+        ifTicked.leave();
+        return new DoubleVariableFmi2Api(null, null, null, null, timeToTickVar.getExp());
     }
 
     private int getClockIndex(PortFmi3Api clock, ClockInfo type) {
-        switch (type) {
-            case Shift -> {
-                return this.clocks.indexOf(clock) * 2 + 1;
-            }
-            case Interval -> {
-                return this.clocks.indexOf(clock) * 2;
-            }
-        }
-        throw new RuntimeException("unknown clock info type: " + type);
+        return this.clocks.indexOf(clock) * ClockInfo.values().length + type.value;
     }
 
     public void storeInterval(FmiBuilder.Scope<PStm> scope, PortFmi3Api clock, PExp interval) {
@@ -93,8 +161,8 @@ public class InstanceClocksFmi3 {
                 .add(newAAssignmentStm(getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Interval)).getDesignator(), interval));
     }
 
-    public PExp getInterval(PortFmi3Api clock) {
-        return getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Interval)).getReferenceExp();
+    public VariableFmi2Api<DoubleVariableFmi2Api> getInterval(PortFmi3Api clock) {
+        return getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Interval));
     }
 
     public void storeShift(FmiBuilder.Scope<PStm> scope, PortFmi3Api clock, PExp shift) {
@@ -102,33 +170,71 @@ public class InstanceClocksFmi3 {
                 .add(newAAssignmentStm(getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Shift)).getDesignator(), shift));
     }
 
-    public PExp getShift(PortFmi3Api clock) {
-        return getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Shift)).getReferenceExp();
+    public VariableFmi2Api<DoubleVariableFmi2Api> getShift(PortFmi3Api clock) {
+        return getClockTimingVar().items().get(getClockIndex(clock, ClockInfo.Shift));
     }
 
     private ArrayVariableFmi2Api<DoubleVariableFmi2Api> getClockTimingVar() {
 
         if (this.timingDataStorage == null) {
-            final int length = this.clocks.size() * 2;
+            final int length = this.clocks.size() * ClockInfo.values().length;
             final PType type = new ARealNumericPrimitiveType();
-            timingDataStorage = createDataArray(length, "clocks_timing_data", type);
+            timingDataStorage = createDataArray(length, "clocks_timing", type);
         }
         return this.timingDataStorage;
     }
 
-    private <C extends VariableFmi2Api> ArrayVariableFmi2Api<C> createDataArray(int length, String name, PType type) {
+    private PStm getOrCreate(PStm var) {
 
-        String ioBufName = builder.getNameGenerator().getName(this.owner.getName(), name);
-
-        PStm var = newALocalVariableStm(newAVariableDeclaration(newAIdentifier(ioBufName), type, length, null));
+        if (builder instanceof ExpansionMableApiBuilder expBuilder && var instanceof ALocalVariableStm stm) {
+            var decl = expBuilder.findDecleration(this.owner.getDeclaredScope(), stm.getDeclaration().getName().getText());
+            if (decl != null) {
+                return decl.getValue();
+            }
+        }
 
         this.owner.getDeclaredScope().addAfter(this.owner.getDeclaringStm(), var);
+        return var;
+    }
 
-        List<VariableFmi2Api> items = IntStream.range(0, length)
-                .mapToObj(i -> new VariableFmi2Api<>(var, type, this.owner.getDeclaredScope(), builder.getDynamicScope(),
-                        newAArayStateDesignator(newAIdentifierStateDesignator(newAIdentifier(ioBufName)), newAIntLiteralExp(i)),
-                        newAArrayIndexExp(newAIdentifierExp(ioBufName), Collections.singletonList(newAIntLiteralExp(i))))).collect(Collectors.toList());
+    @SuppressWarnings("deprecation")
+    private <C extends VariableFmi2Api> ArrayVariableFmi2Api<C> createDataArray(int length, String name, PType type) {
 
+        String ioBufName = this.owner.getName() + name;// builder.getNameGenerator().getName(this.owner.getName(), name);
+
+        PStm var = getOrCreate(newALocalVariableStm(newAVariableDeclaration(newAIdentifier(ioBufName), type, length,
+                new AArrayInitializer(Stream.generate(() -> (PExp) new AIntLiteralExp(null, 0)).limit(length).toList()))));
+
+//        this.owner.getDeclaredScope().addAfter(this.owner.getDeclaringStm(), var);
+
+        List<VariableFmi2Api> items;
+        if (name.equals("clocks_timing")) {
+            //for better readability we need to index with names
+            var indexedNames = Arrays.stream(ClockInfo.values()).sorted(Comparator.comparingInt(a -> a.value)).toList();
+            var index2Name = indexedNames.stream()
+                    .collect(Collectors.toMap(Function.identity(), index -> index.name().toUpperCase()));
+
+            indexedNames.forEach(index -> {
+                var indexVar = newALocalVariableStm(newAVariableDeclaration(newAIdentifier(index2Name.get(index)), newAIntNumericPrimitiveType(),
+                        new AExpInitializer(new AIntLiteralExp(null, index.value))));
+//                this.owner.getDeclaredScope().addAfter(this.owner.getDeclaringStm(), indexVar);
+                getOrCreate(indexVar);
+            });
+            items = indexedNames.stream().map(index -> {
+
+                var indexExp = new AIdentifierExp(null, new LexIdentifier(index2Name.get(index), null));
+
+                return new VariableFmi2Api<>(var, type, this.owner.getDeclaredScope(), builder.getDynamicScope(),
+                        newAArayStateDesignator(newAIdentifierStateDesignator(newAIdentifier(ioBufName)), indexExp.clone()),
+                        newAArrayIndexExp(newAIdentifierExp(ioBufName), Collections.singletonList(indexExp.clone())));
+
+            }).collect(Collectors.toList());
+        } else {
+            items = IntStream.range(0, length)
+                    .mapToObj(i -> new VariableFmi2Api<>(var, type, this.owner.getDeclaredScope(), builder.getDynamicScope(),
+                            newAArayStateDesignator(newAIdentifierStateDesignator(newAIdentifier(ioBufName)), newAIntLiteralExp(i)),
+                            newAArrayIndexExp(newAIdentifierExp(ioBufName), Collections.singletonList(newAIntLiteralExp(i))))).collect(Collectors.toList());
+        }
         return new ArrayVariableFmi2Api(var, type, this.owner.getDeclaredScope(), builder.getDynamicScope(),
                 newAIdentifierStateDesignator(newAIdentifier(ioBufName)),
                 newAIdentifierExp(ioBufName), items.stream().collect(Collectors.toList()));
@@ -165,10 +271,47 @@ public class InstanceClocksFmi3 {
                 call(this.owner.getReferenceExp().clone(), "getIntervalDecimal", args));
         scope.add(stm);
 
-           this.owner. handleError(scope, new InstanceVariableFmi3Api.CallContext("getIntervalDecimal", args));
+        this.owner.handleError(scope, new InstanceVariableFmi3Api.CallContext("getIntervalDecimal", args));
 
         for (short i = 0; i < selectedPorts.size(); i++) {
             this.storeInterval(scope, selectedPorts.get(i), intervalBuf.items().get(i).getReferenceExp().clone());
+        }
+    }
+
+
+    public void updateClockShifts(FmiBuilder.Scope<PStm> scope, ArrayVariableFmi2Api<Object> vrefBuf,
+                                  FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm>... ports) {
+
+        List<PortFmi3Api> selectedPorts;
+        if (ports == null || ports.length == 0) {
+            return;// Map.of();
+        } else {
+            selectedPorts = Arrays.stream(ports).map(PortFmi3Api.class::cast).filter(isClock).filter(isCausalityInput).toList();
+        }
+
+        for (int i = 0; i < selectedPorts.size(); i++) {
+            PortFmi3Api p = selectedPorts.get(i);
+            PStateDesignator designator = vrefBuf.items().get(i).getDesignator().clone();
+            scope.add(newAAssignmentStm(designator, newAIntLiteralExp(p.getPortReferenceValue().intValue())));
+        }
+
+
+        var shiftBuffer1 = getShiftBuffer();
+
+
+//        int getShiftDecimal(uint valueReferences[], int nValueReferences, real shifts[]);
+
+        List<PExp> args = new ArrayList<>(
+                List.of(vrefBuf.getReferenceExp().clone(), newAUIntLiteralExp((long) selectedPorts.size()),
+                        newARefExp(shiftBuffer1.getReferenceExp().clone())));
+        AAssigmentStm stm = newAAssignmentStm(((IMablScope) scope).getFmiStatusVariable().getDesignator().clone(),
+                call(this.owner.getReferenceExp().clone(), "getShiftDecimal", args));
+        scope.add(stm);
+
+        this.owner.handleError(scope, new InstanceVariableFmi3Api.CallContext("getShiftDecimal", args));
+
+        for (short i = 0; i < selectedPorts.size(); i++) {
+            this.storeShift(scope, selectedPorts.get(i), shiftBuffer1.items().get(i).getReferenceExp().clone());
         }
     }
 }

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/InstanceVariableFmi3Api.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/InstanceVariableFmi3Api.java
@@ -2,6 +2,7 @@ package org.intocps.maestro.framework.fmi2.api.mabl.variables;
 
 import org.intocps.maestro.ast.AVariableDeclaration;
 import org.intocps.maestro.ast.LexIdentifier;
+import org.intocps.maestro.ast.LexLocation;
 import org.intocps.maestro.ast.MableAstFactory;
 import org.intocps.maestro.ast.analysis.AnalysisException;
 import org.intocps.maestro.ast.analysis.DepthFirstAnalysisAdaptor;
@@ -26,6 +27,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toSet;
 import static org.intocps.maestro.ast.MableAstFactory.*;
@@ -48,9 +50,12 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 //    private final Map<IMablScope, Map<PortFmi3Api, Integer>> tentativeBufferIndexMap = new HashMap<>();
     private final String environmentName;
 
+    static ARefExp wrapAsRef(PExp exp) {
+        return new ARefExp(new LexLocation(exp.getLocation()), exp.clone());
+    }
 
     private final Buffers<Fmi3TypeEnum> buffers;
-    Predicate<FmiBuilder.Port> isLinked = p -> ((PortFmi3Api) p).getSourcePort() != null;
+    public final static Predicate<FmiBuilder.Port> isLinked = p -> ((PortFmi3Api) p).getSourcePort() != null;
     ModelDescriptionContext3 modelDescriptionContext;
     private ArrayVariableFmi2Api<Object> derSharedBuffer;
     private DoubleVariableFmi2Api currentTimeVar = null;
@@ -61,6 +66,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 
     Predicate<FmiBuilder.Port> obtainAsShared = p -> p.isLinked() || (variablesToLog != null && variablesToLog.contains(p.getName()));
 
+    private final InstanceClocksFmi3 clocksUtil;
     public InstanceVariableFmi3Api(PStm declaration, FmuVariableFmi3Api parent, String name, ModelDescriptionContext3 modelDescriptionContext,
                                    MablApiBuilder builder, IMablScope declaringScope, PStateDesignator designator, PExp referenceExp) {
         this(declaration, parent, name, modelDescriptionContext, builder, declaringScope, designator, referenceExp, name);
@@ -90,6 +96,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
                 .stream().collect(Collectors.groupingBy(i -> i.getVariable().getTypeIdentifier())).entrySet().stream().collect(
                         Collectors.toMap(Map.Entry::getKey, l -> l.getValue().size()));
         this.buffers = new Buffers<>(builder, name, getDeclaringStm(), (ScopeFmi2Api) getDeclaredScope(), svTypeMaxCount);
+        this.clocksUtil = new InstanceClocksFmi3(builder,this);
     }
 
     public Fmi3ModelDescription getModelDescription() {
@@ -228,7 +235,8 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
         String ioBufName = builder.getNameGenerator().getName(name);
 
         PType type = new ABooleanPrimitiveType();
-        PStm var = newALocalVariableStm(newAVariableDeclaration(newAIdentifier(ioBufName), type, new AExpInitializer(new ABoolLiteralExp(initial))));
+        PStm var = newALocalVariableStm(
+                newAVariableDeclaration(newAIdentifier(ioBufName), type, new AExpInitializer(new ABoolLiteralExp(new LexLocation("", 0, 0), initial))));
 
         getDeclaredScope().addAfter(getDeclaringStm(), var);
 
@@ -241,7 +249,8 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
         String ioBufName = builder.getNameGenerator().getName(name);
 
         PType type = new ARealNumericPrimitiveType();
-        PStm var = newALocalVariableStm(newAVariableDeclaration(newAIdentifier(ioBufName), type, new AExpInitializer(new ARealLiteralExp(initial))));
+        PStm var = newALocalVariableStm(
+                newAVariableDeclaration(newAIdentifier(ioBufName), type, new AExpInitializer(new ARealLiteralExp(new LexLocation("", 0, 0), initial))));
 
         getDeclaredScope().addAfter(getDeclaringStm(), var);
 
@@ -273,7 +282,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 
         scope.add(arrayContent, callStm);
 
-        handleError(scope, method);
+        handleError(scope, new CallContext(name, null));
     }
 
     @Override
@@ -302,7 +311,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
                         Arrays.asList(newABoolLiteralExp(tolerance != null), newARealLiteralExp(tolerance != null ? tolerance : 0d),
                                 startTime.clone(), endTimeDefined, endTime != null ? endTime.clone() : newARealLiteralExp(0d)))));
         scope.add(stm);
-        handleError(scope, method);
+        handleError(scope, new CallContext(name, null));
     }
 
     @Override
@@ -340,7 +349,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 
         scope.add(stm);
 
-        handleError(scope, method);
+        handleError(scope, new CallContext(method, null));
     }
 
     public void enterEventMode() {
@@ -365,21 +374,21 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
     public void getEventIndicators(FmiBuilder.Scope<PStm> scope, FmiBuilder.ArrayVariable<PStm, ? extends FmiBuilder.UIntVariable<PStm>> eventIndicators,
                                    FmiBuilder.UIntVariable<PStm> nEventIndicators) {
 
-        fmiCall(scope, "getEventIndicators", new ARefExp(eventIndicators.getExp().clone()), nEventIndicators.getExp().clone());
+        fmiCall(scope, "getEventIndicators", wrapAsRef(eventIndicators.getExp().clone()), nEventIndicators.getExp().clone());
 
     }
 
     public void getNumberOfEventIndicators(FmiBuilder.Scope<PStm> scope, FmiBuilder.UIntVariable<PStm> nEventIndicators) {
-        fmiCall(scope, "getNumberOfEventIndicators", new ARefExp(nEventIndicators.getExp().clone()));
+        fmiCall(scope, "getNumberOfEventIndicators", wrapAsRef(nEventIndicators.getExp().clone()));
     }
 
-    private void handleError(FmiBuilder.Scope<PStm> scope, String method) {
-        handleError(scope, method, MablApiBuilder.Fmi3Status.FMI_ERROR, MablApiBuilder.Fmi3Status.FMI_FATAL);
+     void handleError(FmiBuilder.Scope<PStm> scope, CallContext callContext) {
+        handleError(scope, callContext.name(), callContext, MablApiBuilder.Fmi3Status.FMI_ERROR, MablApiBuilder.Fmi3Status.FMI_FATAL);
     }
 
-    private void handleError(FmiBuilder.Scope<PStm> scope, String method, MablApiBuilder.Fmi3Status... statusesToFail) {
+    private void handleError(FmiBuilder.Scope<PStm> scope, String method, CallContext callContext, MablApiBuilder.Fmi3Status... statusesToFail) {
         if (builder.getSettings().fmiErrorHandlingEnabled) {
-            FmiStatusErrorHandlingBuilder.generate(builder, method, this, (IMablScope) scope, statusesToFail);
+            FmiStatusErrorHandlingBuilder.generate(builder, this, (IMablScope) scope, callContext, statusesToFail);
         }
     }
 
@@ -403,7 +412,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 
     @Override
     public void exitInitializationMode(FmiBuilder.Scope<PStm> scope) {
-        fmiCall(scope,"exitInitializationMode");
+        fmiCall(scope, "exitInitializationMode");
     }
 
     public void getClock(ArrayVariableFmi2Api<UIntVariableFmi2Api> vrs, FmiBuilder.IntVariable<PStm> nvr,
@@ -414,8 +423,8 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 
     public void getClock(FmiBuilder.Scope<PStm> scope, ArrayVariableFmi2Api<UIntVariableFmi2Api> vrs, FmiBuilder.IntVariable<PStm> nvr,
                          ArrayVariableFmi2Api<BooleanVariableFmi2Api> triggeredClocks) {
-        fmiCall(scope,"getClock", vrs.getReferenceExp().clone(), nvr.getExp().clone(),
-                                new ARefExp(triggeredClocks.getExp().clone()));
+        fmiCall(scope, "getClock", vrs.getReferenceExp().clone(), nvr.getExp().clone(),
+                wrapAsRef(triggeredClocks.getExp().clone()));
     }
 
     public void setClock(ArrayVariableFmi2Api<UIntVariableFmi2Api> vrs, FmiBuilder.IntVariable<PStm> nvr,
@@ -427,8 +436,8 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
     public void setClock(FmiBuilder.Scope<PStm> scope, ArrayVariableFmi2Api<UIntVariableFmi2Api> vrs, FmiBuilder.IntVariable<PStm> nvr,
                          ArrayVariableFmi2Api<BooleanVariableFmi2Api> triggeredClocks) {
 
-        fmiCall(scope,"setClock", vrs.getReferenceExp().clone(), nvr.getExp().clone(),
-                                triggeredClocks.getExp().clone());
+        fmiCall(scope, "setClock", vrs.getReferenceExp().clone(), nvr.getExp().clone(),
+                triggeredClocks.getExp().clone());
 
     }
 
@@ -437,13 +446,13 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
                                      BooleanVariableFmi2Api nominalsOfContinuousStatesChanged, BooleanVariableFmi2Api valuesOfContinuousStatesChanged,
                                      BooleanVariableFmi2Api nextEventTimeDefined, DoubleVariableFmi2Api nextEventTime) {
 
-        fmiCall(scope,"updateDiscreteStates",
-                                new ARefExp(discreteStatesNeedUpdate.getReferenceExp().clone()),
-                                new ARefExp(terminateSimulation.getReferenceExp().clone()),
-                                new ARefExp(nominalsOfContinuousStatesChanged.getReferenceExp().clone()),
-                                new ARefExp(valuesOfContinuousStatesChanged.getReferenceExp().clone()),
-                                new ARefExp(nextEventTimeDefined.getReferenceExp().clone()),
-                                new ARefExp(nextEventTime.getReferenceExp().clone()));
+        fmiCall(scope, "updateDiscreteStates",
+                wrapAsRef(discreteStatesNeedUpdate.getReferenceExp().clone()),
+                wrapAsRef(terminateSimulation.getReferenceExp().clone()),
+                wrapAsRef(nominalsOfContinuousStatesChanged.getReferenceExp().clone()),
+                wrapAsRef(valuesOfContinuousStatesChanged.getReferenceExp().clone()),
+                wrapAsRef(nextEventTimeDefined.getReferenceExp().clone()),
+                wrapAsRef(nextEventTime.getReferenceExp().clone()));
 
     }
 
@@ -523,10 +532,10 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
                 newACallExp(this.getReferenceExp().clone(), newAIdentifier("doStep"),
                         Arrays.asList(((VariableFmi2Api) currentCommunicationPoint).getReferenceExp().clone(),
                                 ((VariableFmi2Api) communicationStepSize).getReferenceExp().clone(), noSetFMUStatePriorToCurrentPoint.clone(),
-                                new ARefExp(stepResult.eventHandlingNeeded.getReferenceExp()).clone(),
-                                new ARefExp(stepResult.terminateSimulation.getReferenceExp()).clone(),
-                                new ARefExp(stepResult.earlyReturn.getReferenceExp()).clone(),
-                                new ARefExp(stepResult.lastSuccessfulTime.getReferenceExp()).clone()))));
+                                wrapAsRef(stepResult.eventHandlingNeeded.getReferenceExp()).clone(),
+                                wrapAsRef(stepResult.terminateSimulation.getReferenceExp()).clone(),
+                                wrapAsRef(stepResult.earlyReturn.getReferenceExp()).clone(),
+                                wrapAsRef(stepResult.lastSuccessfulTime.getReferenceExp()).clone()))));
 
         /*
               int doStep(
@@ -546,7 +555,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 
 
         if (builder.getSettings().fmiErrorHandlingEnabled) {
-            FmiStatusErrorHandlingBuilder.generate(builder, "doStep", this, (IMablScope) scope, MablApiBuilder.Fmi3Status.FMI_ERROR,
+            FmiStatusErrorHandlingBuilder.generate(builder, this, (IMablScope) scope, new CallContext("doStep", null), MablApiBuilder.Fmi3Status.FMI_ERROR,
                     MablApiBuilder.Fmi3Status.FMI_FATAL);
         }
 
@@ -681,13 +690,19 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
             ArrayVariableFmi2Api<Object> valBuf = this.buffers.getBuffer(Buffers.BufferTypes.IO, type,
                     firstTargetPort.getSourceObject().getVariable().getTypeIdentifier());
 
+            List<PExp> args = new ArrayList<>(
+                    List.of(vrefBuf.getReferenceExp().clone(), newAUIntLiteralExp((long) e.getValue().size()), newARefExp(valBuf.getReferenceExp().clone())));
+            if (firstTargetPort.scalarVariable != null && firstTargetPort.scalarVariable.getVariable().getTypeIdentifier() == Fmi3TypeEnum.ClockType) {
+                // clocks do not have the latter size included
+            } else {
+                args.add(
+                        newAUIntLiteralExp((long) e.getValue().size()));
+            }
             AAssigmentStm stm = newAAssignmentStm(((IMablScope) scope).getFmiStatusVariable().getDesignator().clone(),
-                    call(this.getReferenceExp().clone(), createFunctionName(FmiFunctionType.GET, firstTargetPort),
-                            vrefBuf.getReferenceExp().clone(), newAUIntLiteralExp((long) e.getValue().size()), newARefExp(valBuf.getReferenceExp().clone()),
-                            newAUIntLiteralExp((long) e.getValue().size())));
+                    call(this.getReferenceExp().clone(), createFunctionName(FmiFunctionType.GET, firstTargetPort), args));
             scope.add(stm);
 
-            handleError(scope, createFunctionName(FmiFunctionType.GET, firstTargetPort));
+            handleError(scope, new CallContext(createFunctionName(FmiFunctionType.GET, firstTargetPort), args));
 
             if (builder.getSettings().setGetDerivatives && type.equals(new ARealNumericPrimitiveType())) {
                 derivativePortsToShare = getDerivatives(e.getValue(), scope);
@@ -991,12 +1006,22 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
                         portToValue.apply(p).getValue(), valBuf.type));
             }
 
+
+            List<PExp> args = new ArrayList<>(
+                    List.of(vrefBuf.getReferenceExp().clone(),
+                            newAIntLiteralExp(value.size()), valBuf.getReferenceExp().clone()));
+            if (firstTargetPort.scalarVariable != null && firstTargetPort.scalarVariable.getVariable().getTypeIdentifier() == Fmi3TypeEnum.ClockType) {
+                // clocks do not have the latter size included
+            } else {
+                args.add(
+                        newAIntLiteralExp(value.size()));
+            }
+
             AAssigmentStm stm = newAAssignmentStm(((IMablScope) scope).getFmiStatusVariable().getDesignator().clone(),
-                    call(this.getReferenceExp().clone(), createFunctionName(FmiFunctionType.SET, firstTargetPort), vrefBuf.getReferenceExp().clone(),
-                            newAIntLiteralExp(value.size()), valBuf.getReferenceExp().clone(), newAIntLiteralExp(value.size())));
+                    call(this.getReferenceExp().clone(), createFunctionName(FmiFunctionType.SET, firstTargetPort), args));
             scope.add(stm);
 
-            handleError(scope, createFunctionName(FmiFunctionType.SET, firstTargetPort));
+            handleError(scope, new CallContext(createFunctionName(FmiFunctionType.SET, firstTargetPort), args));
 
             // TODO: IntermediateUpdateMode instead of CanInterpolateInputs?
             // TODO: commented out for no so it compiles
@@ -1098,7 +1123,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
                         derOrderInBuf.getReferenceExp().clone(), derValInBuf.getReferenceExp().clone()));
         scope.add(ifStm);
 
-        handleError(scope, method);
+        handleError(scope, new CallContext(method, null));
     }
 
     @Override
@@ -1217,6 +1242,68 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
     }
 
     @Override
+    public  Map<? extends FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm>, ? extends FmiBuilder.DoubleVariable<PStm>> getClockInterval(
+            FmiBuilder.Scope<PStm> scope, FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm>... ports) {
+this.clocksUtil.updateClockIntervals(scope,getValueReferenceBuffer(),ports);
+        return Map.of();
+//            List<PortFmi3Api> selectedPorts;
+//            if (ports == null || ports.length == 0) {
+//                return Map.of();
+//            } else {
+//                selectedPorts = Arrays.stream(ports).map(PortFmi3Api.class::cast).filter(isClock).filter(isCausalityInput).collect(Collectors.toList());
+//            }
+//
+//            Map<PortFmi3Api, VariableFmi2Api<V>> results = new HashMap<>();
+//
+//            ArrayVariableFmi2Api<Object> vrefBuf = getValueReferenceBuffer();
+//
+//
+//            for (Map.Entry<Fmi3TypeEnum, List<PortFmi3Api>> e : typeToSortedPorts.entrySet()) {
+//                for (int i = 0; i < e.getValue().size(); i++) {
+//                    PortFmi3Api p = e.getValue().get(i);
+//                    PStateDesignator designator = vrefBuf.items().get(i).getDesignator().clone();
+//                    scope.add(newAAssignmentStm(designator, newAIntLiteralExp(p.getPortReferenceValue().intValue())));
+//                }
+//
+////all ports should have the same type so lets use the first port to define the io array type
+//                PortFmi3Api firstTargetPort = e.getValue().get(0);
+//                PType type = firstTargetPort.getType();
+//
+//                ArrayVariableFmi2Api<Object> valBuf = this.buffers.getBuffer(Buffers.BufferTypes.ClocksTiming, type,
+//                        firstTargetPort.getSourceObject().getVariable().getTypeIdentifier());
+//
+//                List<PExp> args = new ArrayList<>(
+//                        List.of(vrefBuf.getReferenceExp().clone(), newAUIntLiteralExp((long) e.getValue().size()), newARefExp(valBuf.getReferenceExp().clone())));
+////                if (firstTargetPort.scalarVariable != null && firstTargetPort.scalarVariable.getVariable().getTypeIdentifier() == Fmi3TypeEnum.ClockType) {
+////                    // clocks do not have the latter size included
+////                } else {
+////                    args.add(
+////                            newAUIntLiteralExp((long) e.getValue().size()));
+////                }
+//                AAssigmentStm stm = newAAssignmentStm(((IMablScope) scope).getFmiStatusVariable().getDesignator().clone(),
+//                        call(this.getReferenceExp().clone(), createFunctionName(FmiFunctionType.GET, firstTargetPort), args));
+//                scope.add(stm);
+//
+//                handleError(scope, new CallContext(createFunctionName(FmiFunctionType.GET, firstTargetPort), args));
+//
+//                if (builder.getSettings().setGetDerivatives && type.equals(new ARealNumericPrimitiveType())) {
+//                    derivativePortsToShare = getDerivatives(e.getValue(), scope);
+//                }
+//
+//                for (int i = 0; i < e.getValue().size(); i++) {
+//                    results.put(e.getValue().get(i), (VariableFmi2Api<V>) valBuf.items().get(i));
+//                }
+//            }
+//            return results;
+        }
+
+
+    @Override
+    public FmiBuilder.DoubleVariable<PStm> getClockShift(FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm> port) {
+        return null;
+    }
+
+    @Override
     public void terminate(FmiBuilder.Scope<PStm> scope) {
         fmiCall(scope, "terminate");
     }
@@ -1235,7 +1322,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 
         scope.add(stm);
 
-        handleError(scope, methodName);
+        handleError(scope, new CallContext(methodName, Arrays.asList(args)));
     }
 
     // TODO: these are work in progress
@@ -1409,7 +1496,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
                 call(this.getReferenceExp().clone(), "getState", Collections.singletonList(newARefExp(state.getReferenceExp().clone()))));
         scope.add(stm);
         if (builder.getSettings().fmiErrorHandlingEnabled) {
-            FmiStatusErrorHandlingBuilder.generate(builder, "getState", this, (IMablScope) scope, MablApiBuilder.Fmi3Status.FMI_ERROR,
+            FmiStatusErrorHandlingBuilder.generate(builder, this, (IMablScope) scope, new CallContext("getState", null), MablApiBuilder.Fmi3Status.FMI_ERROR,
                     MablApiBuilder.Fmi3Status.FMI_FATAL);
         }
 
@@ -1443,12 +1530,18 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
     /**
      * Error and Fatal should lead to freeInstance calls followed by subsequent termination.
      */
+    static record CallContext(String name, List<PExp> args) {
+    }
+
     static class FmiStatusErrorHandlingBuilder {
-        static void generate(MablApiBuilder builder, String method, InstanceVariableFmi3Api instance, IMablScope scope,
+
+        static void generate(MablApiBuilder builder, InstanceVariableFmi3Api instance, IMablScope scope, CallContext callContext,
                              MablApiBuilder.Fmi3Status... statusesToFail) {
             if (statusesToFail == null || statusesToFail.length == 0) {
                 return;
             }
+
+            final var method = callContext.name();
 
             Function<MablApiBuilder.Fmi3Status, PExp> checkStatusEq =
                     s -> newEqual(scope.getFmiStatusVariable().getReferenceExp().clone(), builder.getFmiStatusConstant(s).getReferenceExp().clone());
@@ -1465,8 +1558,15 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 
             for (MablApiBuilder.Fmi3Status status : statusesToFail) {
                 ScopeFmi2Api s = thenScope.enterIf(new PredicateFmi2Api(checkStatusEq.apply(status))).enterThen();
-                builder.getLogger()
-                        .error(s, method.substring(0, 1).toUpperCase() + method.substring(1) + " failed on '%s' with status: " + status, instance);
+                if (Stream.of("get", "set").anyMatch(
+                        p -> Fmi3TypeEnum.getEntries().stream().anyMatch(t -> method.startsWith(p + t.name().substring(0, t.name().indexOf("Type")))))) {
+                    //we have FMI get/set with vr and nvr
+                    builder.getLogger()
+                            .logFmiCallVRefs(s, callContext.args().get(0).clone(),callContext.args().get(1).clone(),method.substring(0, 1).toUpperCase() + method.substring(1) + " failed on '%s' with status: " + status, instance);
+                } else {
+                    builder.getLogger()
+                            .error(s, method.substring(0, 1).toUpperCase() + method.substring(1) + " failed on '%s' with status: " + status, instance);
+                }
             }
 
             thenScope.add(new AErrorStm(newAStringLiteralExp("Failed to '" + method + "' on '" + instance.getName() + "'")));

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/InstanceVariableFmi3Api.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/InstanceVariableFmi3Api.java
@@ -15,6 +15,7 @@ import org.intocps.maestro.framework.fmi2.api.FmiBuilder;
 import org.intocps.maestro.framework.fmi2.api.mabl.*;
 import org.intocps.maestro.framework.fmi2.api.mabl.scoping.IMablScope;
 import org.intocps.maestro.framework.fmi2.api.mabl.scoping.ScopeFmi2Api;
+import org.intocps.maestro.framework.fmi2.api.mabl.values.IntExpressionValue;
 import org.intocps.maestro.framework.fmi2.api.mabl.values.PortValueExpresssionMapImpl;
 import org.intocps.maestro.framework.fmi2.api.mabl.values.PortValueMapImpl;
 import org.slf4j.Logger;
@@ -23,8 +24,10 @@ import org.slf4j.LoggerFactory;
 import javax.xml.xpath.XPathExpressionException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -34,7 +37,7 @@ import static org.intocps.maestro.ast.MableAstFactory.*;
 import static org.intocps.maestro.ast.MableBuilder.call;
 import static org.intocps.maestro.ast.MableBuilder.newVariable;
 
-@SuppressWarnings("rawtypes")
+@SuppressWarnings({"rawtypes", "deprecation"})
 public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVariable<PStm>> implements FmiBuilder.Fmi3InstanceVariable<PStm, Fmi3ModelDescription.Fmi3ScalarVariable> {
     final static Logger logger = LoggerFactory.getLogger(InstanceVariableFmi3Api.class);
     private final static int FMI_STATUS_LAST_SUCCESSFUL = 2;
@@ -49,6 +52,14 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
     //    private final Map<IMablScope, Map<PType, ArrayVariableFmi2Api<Object>>> tentativeBuffer = new HashMap<>();
 //    private final Map<IMablScope, Map<PortFmi3Api, Integer>> tentativeBufferIndexMap = new HashMap<>();
     private final String environmentName;
+
+    public static final Predicate<InstanceVariableFmi3Api> hasEventMode = instance -> {
+        try {
+            return instance.getModelDescription().getHasEventMode();
+        } catch (XPathExpressionException e) {
+            throw new RuntimeException(e);
+        }
+    };
 
     static ARefExp wrapAsRef(PExp exp) {
         return new ARefExp(new LexLocation(exp.getLocation()), exp.clone());
@@ -66,7 +77,12 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 
     Predicate<FmiBuilder.Port> obtainAsShared = p -> p.isLinked() || (variablesToLog != null && variablesToLog.contains(p.getName()));
 
+    public InstanceClocksFmi3 getClocksUtil() {
+        return clocksUtil;
+    }
+
     private final InstanceClocksFmi3 clocksUtil;
+
     public InstanceVariableFmi3Api(PStm declaration, FmuVariableFmi3Api parent, String name, ModelDescriptionContext3 modelDescriptionContext,
                                    MablApiBuilder builder, IMablScope declaringScope, PStateDesignator designator, PExp referenceExp) {
         this(declaration, parent, name, modelDescriptionContext, builder, declaringScope, designator, referenceExp, name);
@@ -82,13 +98,13 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
         this.builder = builder;
 
         ports = modelDescriptionContext.nameToSv.values().stream().map(sv -> new PortFmi3Api(this, sv))
-                .sorted(Comparator.comparing(PortFmi3Api::getPortReferenceValue)).collect(Collectors.toUnmodifiableList());
+                .sorted(Comparator.comparing(PortFmi3Api::getPortReferenceValue)).toList();
 
         outputPorts = ports.stream().filter(p -> p.scalarVariable.getVariable().getCausality() == Fmi3Causality.Output)
-                .sorted(Comparator.comparing(PortFmi3Api::getPortReferenceValue)).collect(Collectors.toUnmodifiableList());
+                .sorted(Comparator.comparing(PortFmi3Api::getPortReferenceValue)).toList();
 
         inputPorts = ports.stream().filter(p -> p.scalarVariable.getVariable().getCausality() == Fmi3Causality.Input)
-                .sorted(Comparator.comparing(PortFmi3Api::getPortReferenceValue)).collect(Collectors.toUnmodifiableList());
+                .sorted(Comparator.comparing(PortFmi3Api::getPortReferenceValue)).toList();
 
         this.environmentName = environmentName;
 
@@ -96,7 +112,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
                 .stream().collect(Collectors.groupingBy(i -> i.getVariable().getTypeIdentifier())).entrySet().stream().collect(
                         Collectors.toMap(Map.Entry::getKey, l -> l.getValue().size()));
         this.buffers = new Buffers<>(builder, name, getDeclaringStm(), (ScopeFmi2Api) getDeclaredScope(), svTypeMaxCount);
-        this.clocksUtil = new InstanceClocksFmi3(builder,this);
+        this.clocksUtil = new InstanceClocksFmi3(builder, this);
     }
 
     public Fmi3ModelDescription getModelDescription() {
@@ -382,13 +398,14 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
         fmiCall(scope, "getNumberOfEventIndicators", wrapAsRef(nEventIndicators.getExp().clone()));
     }
 
-     void handleError(FmiBuilder.Scope<PStm> scope, CallContext callContext) {
+    void handleError(FmiBuilder.Scope<PStm> scope, CallContext callContext) {
         handleError(scope, callContext.name(), callContext, MablApiBuilder.Fmi3Status.FMI_ERROR, MablApiBuilder.Fmi3Status.FMI_FATAL);
     }
 
     private void handleError(FmiBuilder.Scope<PStm> scope, String method, CallContext callContext, MablApiBuilder.Fmi3Status... statusesToFail) {
         if (builder.getSettings().fmiErrorHandlingEnabled) {
-            FmiStatusErrorHandlingBuilder.generate(builder, this, (IMablScope) scope, callContext, statusesToFail);
+            FmiStatusErrorHandlingBuilder.generate(builder, builder.getSettings().fmiErrorHandlingDetailEnabled, this, (IMablScope) scope, callContext,
+                    statusesToFail);
         }
     }
 
@@ -481,20 +498,12 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 //        return step(dynamicScope, currentCommunicationPoint, communicationStepSize, newABoolLiteralExp(false));
 //    }
 
+
     public static class StepResult {
-        final BooleanVariableFmi2Api eventHandlingNeeded;
-        final BooleanVariableFmi2Api terminateSimulation;
-        final BooleanVariableFmi2Api earlyReturn;
-
-        public StepResult(BooleanVariableFmi2Api eventHandlingNeeded, BooleanVariableFmi2Api terminateSimulation, BooleanVariableFmi2Api earlyReturn,
-                          DoubleVariableFmi2Api lastSuccessfulTime) {
-            this.eventHandlingNeeded = eventHandlingNeeded;
-            this.terminateSimulation = terminateSimulation;
-            this.earlyReturn = earlyReturn;
-            this.lastSuccessfulTime = lastSuccessfulTime;
-        }
-
-        final DoubleVariableFmi2Api lastSuccessfulTime;
+        BooleanVariableFmi2Api eventHandlingNeeded;
+        BooleanVariableFmi2Api terminateSimulation;
+        BooleanVariableFmi2Api earlyReturn;
+        DoubleVariableFmi2Api lastSuccessfulTime;
 
         public BooleanVariableFmi2Api getEventHandlingNeeded() {
             return eventHandlingNeeded;
@@ -511,31 +520,71 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
         public DoubleVariableFmi2Api getLastSuccessfulTime() {
             return lastSuccessfulTime;
         }
+
+        public StepResult(BooleanVariableFmi2Api eventHandlingNeeded, BooleanVariableFmi2Api terminateSimulation, BooleanVariableFmi2Api earlyReturn,
+                          DoubleVariableFmi2Api lastSuccessfulTime) {
+            this.eventHandlingNeeded = eventHandlingNeeded;
+            this.terminateSimulation = terminateSimulation;
+            this.earlyReturn = earlyReturn;
+            this.lastSuccessfulTime = lastSuccessfulTime;
+        }
     }
 
-    StepResult stepResult;
+    StepResult stepResult = new StepResult(null, null, null, null);
 
     public Map.Entry<FmiBuilder.BoolVariable<PStm>, StepResult> step(FmiBuilder.Scope<PStm> scope,
                                                                      FmiBuilder.DoubleVariable<PStm> currentCommunicationPoint,
                                                                      FmiBuilder.DoubleVariable<PStm> communicationStepSize,
-                                                                     PExp noSetFMUStatePriorToCurrentPoint) {
 
-        if (stepResult == null) {
-            stepResult = new StepResult(createReusableBooleanVariable(false, this.getDeclaredScope(), this.name + "EventHandlingNeeded"),
-                    createReusableBooleanVariable(false, this.getDeclaredScope(), this.name + "TerminateSimulation"),
-                    createReusableBooleanVariable(false, this.getDeclaredScope(), this.name + "EarlyReturn"),
-                    createReusableDoubleVariable(0d, this.getDeclaredScope(), this.name + "LastSuccessfulTime"));
+                                                                     PExp noSetFMUStatePriorToCurrentPoint, StepResult optionalStepResult) {
+        final String namePrefix = this.name;
+        final IMablScope declareScope = this.getDeclaredScope();
+        Function<String, BooleanVariableFmi2Api> booleanVariableSupplier = n -> createReusableBooleanVariable(false, declareScope, namePrefix + n);
+
+        var evenHandlingNeeded = optionalStepResult == null ? null : optionalStepResult.eventHandlingNeeded;
+        if (evenHandlingNeeded == null) {
+            if (stepResult.eventHandlingNeeded == null) {
+                evenHandlingNeeded = booleanVariableSupplier.apply("EventHandlingNeeded");
+                stepResult.eventHandlingNeeded = evenHandlingNeeded;
+            }
         }
+
+        var terminateSimulation = optionalStepResult == null ? null : optionalStepResult.terminateSimulation;
+        if (terminateSimulation == null) {
+            if (stepResult.terminateSimulation == null) {
+                terminateSimulation = booleanVariableSupplier.apply("TerminateSimulation");
+                stepResult.terminateSimulation = terminateSimulation;
+            }
+        }
+
+        var earlyReturn = optionalStepResult == null ? null : optionalStepResult.earlyReturn;
+        if (earlyReturn == null) {
+            if (stepResult.earlyReturn == null) {
+                earlyReturn = booleanVariableSupplier.apply("EarlyReturn");
+                stepResult.earlyReturn = earlyReturn;
+            }
+        }
+
+        var lastSuccessfulTime = optionalStepResult == null ? null : optionalStepResult.lastSuccessfulTime;
+        if (lastSuccessfulTime == null) {
+            if (stepResult.lastSuccessfulTime == null) {
+                lastSuccessfulTime = createReusableDoubleVariable(0d, this.getDeclaredScope(), this.name + "LastSuccessfulTime");
+                stepResult.lastSuccessfulTime = lastSuccessfulTime;
+            }
+        }
+
+
+        var result = new StepResult(evenHandlingNeeded, terminateSimulation, earlyReturn, lastSuccessfulTime);
 
 
         scope.add(newAAssignmentStm(((IMablScope) scope).getFmiStatusVariable().getDesignator().clone(),
                 newACallExp(this.getReferenceExp().clone(), newAIdentifier("doStep"),
                         Arrays.asList(((VariableFmi2Api) currentCommunicationPoint).getReferenceExp().clone(),
                                 ((VariableFmi2Api) communicationStepSize).getReferenceExp().clone(), noSetFMUStatePriorToCurrentPoint.clone(),
-                                wrapAsRef(stepResult.eventHandlingNeeded.getReferenceExp()).clone(),
-                                wrapAsRef(stepResult.terminateSimulation.getReferenceExp()).clone(),
-                                wrapAsRef(stepResult.earlyReturn.getReferenceExp()).clone(),
-                                wrapAsRef(stepResult.lastSuccessfulTime.getReferenceExp()).clone()))));
+                                wrapAsRef(result.eventHandlingNeeded.getReferenceExp()).clone(),
+                                wrapAsRef(result.terminateSimulation.getReferenceExp()).clone(),
+                                wrapAsRef(result.earlyReturn.getReferenceExp()).clone(),
+                                wrapAsRef(result.lastSuccessfulTime.getReferenceExp()).clone()))));
 
         /*
               int doStep(
@@ -555,7 +604,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 
 
         if (builder.getSettings().fmiErrorHandlingEnabled) {
-            FmiStatusErrorHandlingBuilder.generate(builder, this, (IMablScope) scope, new CallContext("doStep", null), MablApiBuilder.Fmi3Status.FMI_ERROR,
+            FmiStatusErrorHandlingBuilder.generate(builder, builder.getSettings().fmiErrorHandlingDetailEnabled,this, (IMablScope) scope, new CallContext("doStep", null), MablApiBuilder.Fmi3Status.FMI_ERROR,
                     MablApiBuilder.Fmi3Status.FMI_FATAL);
         }
 
@@ -574,7 +623,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 //                                ((VariableFmi2Api<?>) communicationStepSize).getReferenceExp().clone())),
 //                newAAssignmentStm(getCurrentTimeFullStepVar().getDesignator().clone(), newABoolLiteralExp(true)))));
 
-        return Map.entry(getCurrentTimeFullStepVar(), this.stepResult);
+        return Map.entry(getCurrentTimeFullStepVar(), result);
     }
 
     @Override
@@ -590,18 +639,18 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 
     @Override
     public List<PortFmi3Api> getPorts(int... valueReferences) {
-        List<Integer> accept = Arrays.stream(valueReferences).boxed().collect(Collectors.toList());
+        List<Integer> accept = Arrays.stream(valueReferences).boxed().toList();
         return ports.stream().filter(p -> accept.contains(p.getPortReferenceValue().intValue())).collect(Collectors.toList());
     }
 
     @Override
     public PortFmi3Api getPort(String name) {
-        return this.getPorts(name).get(0);
+        return this.getPorts(name).getFirst();
     }
 
     @Override
     public PortFmi3Api getPort(int valueReference) {
-        return this.getPorts(valueReference).get(0);
+        return this.getPorts(valueReference).getFirst();
     }
 
     //TODO: Move tentative buffer and global share buffer logic to its own module so that it is not coupled with the component logic?
@@ -663,7 +712,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
         if (ports == null || ports.length == 0) {
             return Map.of();
         } else {
-            selectedPorts = Arrays.stream(ports).map(PortFmi3Api.class::cast).collect(Collectors.toList());
+            selectedPorts = Arrays.stream(ports).map(PortFmi3Api.class::cast).toList();
         }
 
         Map<PortFmi3Api, VariableFmi2Api<V>> results = new HashMap<>();
@@ -674,7 +723,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
         selectedPorts.stream().map(p -> p.scalarVariable.getVariable().getTypeIdentifier()).distinct()
                 .map(t -> selectedPorts.stream().filter(p -> p.scalarVariable.getVariable().getTypeIdentifier().equals(t))
                         .sorted(Comparator.comparing(FmiBuilder.Port::getPortReferenceValue)).collect(Collectors.toList()))
-                .forEach(l -> typeToSortedPorts.put(l.get(0).scalarVariable.getVariable().getTypeIdentifier(), l));
+                .forEach(l -> typeToSortedPorts.put(l.getFirst().scalarVariable.getVariable().getTypeIdentifier(), l));
 
         for (Map.Entry<Fmi3TypeEnum, List<PortFmi3Api>> e : typeToSortedPorts.entrySet()) {
             for (int i = 0; i < e.getValue().size(); i++) {
@@ -684,7 +733,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
             }
 
 //all ports should have the same type so lets use the first port to define the io array type
-            PortFmi3Api firstTargetPort = e.getValue().get(0);
+            PortFmi3Api firstTargetPort = e.getValue().getFirst();
             PType type = firstTargetPort.getType();
 
             ArrayVariableFmi2Api<Object> valBuf = this.buffers.getBuffer(Buffers.BufferTypes.IO, type,
@@ -807,7 +856,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
     @SuppressWarnings("unchecked")
     @Override
     public <V> Map<PortFmi3Api, VariableFmi2Api<V>> get(int... valueReferences) {
-        List<Integer> accept = Arrays.stream(valueReferences).boxed().collect(Collectors.toList());
+        List<Integer> accept = Arrays.stream(valueReferences).boxed().toList();
         return get(builder.getDynamicScope(),
                 outputPorts.stream().filter(p -> accept.contains(p.getPortReferenceValue().intValue())).toArray(FmiBuilder.Port[]::new));
     }
@@ -983,12 +1032,12 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
         }
 
         List<PortFmi3Api> sortedPorts =
-                selectedPorts.stream().sorted(Comparator.comparing(FmiBuilder.Port::getPortReferenceValue)).collect(Collectors.toList());
+                selectedPorts.stream().sorted(Comparator.comparing(FmiBuilder.Port::getPortReferenceValue)).toList();
 
         // Group by the string value of the port type as grouping by the port type itself doesnt utilise equals
         sortedPorts.stream().collect(Collectors.groupingBy(i -> i.getSourceObject().getVariable().getTypeIdentifier().toString())).forEach((key, value) -> {
             ArrayVariableFmi2Api<Object> vrefBuf = getValueReferenceBuffer();
-            PortFmi3Api firstTargetPort = value.get(0);
+            PortFmi3Api firstTargetPort = value.getFirst();
             PType type = firstTargetPort.getType();
             for (int i = 0; i < value.size(); i++) {
                 FmiBuilder.Port p = value.get(i);
@@ -1221,7 +1270,7 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
     @SuppressWarnings("unchecked")
     @Override
     public void setLinked(long... filterValueReferences) {
-        List<Long> accept = Arrays.stream(filterValueReferences).boxed().collect(Collectors.toList());
+        List<Long> accept = Arrays.stream(filterValueReferences).boxed().toList();
         this.setLinked(dynamicScope, getPorts().stream().filter(p -> accept.contains(p.getPortReferenceValue())).toArray(FmiBuilder.Port[]::new));
 
     }
@@ -1242,65 +1291,45 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
     }
 
     @Override
-    public  Map<? extends FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm>, ? extends FmiBuilder.DoubleVariable<PStm>> getClockInterval(
+    public Map<? extends FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm>, ? extends FmiBuilder.DoubleVariable<PStm>> getClockInterval(
             FmiBuilder.Scope<PStm> scope, FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm>... ports) {
-this.clocksUtil.updateClockIntervals(scope,getValueReferenceBuffer(),ports);
+        this.clocksUtil.updateClockIntervals(scope, getValueReferenceBuffer(), ports);
         return Map.of();
-//            List<PortFmi3Api> selectedPorts;
-//            if (ports == null || ports.length == 0) {
-//                return Map.of();
-//            } else {
-//                selectedPorts = Arrays.stream(ports).map(PortFmi3Api.class::cast).filter(isClock).filter(isCausalityInput).collect(Collectors.toList());
-//            }
-//
-//            Map<PortFmi3Api, VariableFmi2Api<V>> results = new HashMap<>();
-//
-//            ArrayVariableFmi2Api<Object> vrefBuf = getValueReferenceBuffer();
-//
-//
-//            for (Map.Entry<Fmi3TypeEnum, List<PortFmi3Api>> e : typeToSortedPorts.entrySet()) {
-//                for (int i = 0; i < e.getValue().size(); i++) {
-//                    PortFmi3Api p = e.getValue().get(i);
-//                    PStateDesignator designator = vrefBuf.items().get(i).getDesignator().clone();
-//                    scope.add(newAAssignmentStm(designator, newAIntLiteralExp(p.getPortReferenceValue().intValue())));
-//                }
-//
-////all ports should have the same type so lets use the first port to define the io array type
-//                PortFmi3Api firstTargetPort = e.getValue().get(0);
-//                PType type = firstTargetPort.getType();
-//
-//                ArrayVariableFmi2Api<Object> valBuf = this.buffers.getBuffer(Buffers.BufferTypes.ClocksTiming, type,
-//                        firstTargetPort.getSourceObject().getVariable().getTypeIdentifier());
-//
-//                List<PExp> args = new ArrayList<>(
-//                        List.of(vrefBuf.getReferenceExp().clone(), newAUIntLiteralExp((long) e.getValue().size()), newARefExp(valBuf.getReferenceExp().clone())));
-////                if (firstTargetPort.scalarVariable != null && firstTargetPort.scalarVariable.getVariable().getTypeIdentifier() == Fmi3TypeEnum.ClockType) {
-////                    // clocks do not have the latter size included
-////                } else {
-////                    args.add(
-////                            newAUIntLiteralExp((long) e.getValue().size()));
-////                }
-//                AAssigmentStm stm = newAAssignmentStm(((IMablScope) scope).getFmiStatusVariable().getDesignator().clone(),
-//                        call(this.getReferenceExp().clone(), createFunctionName(FmiFunctionType.GET, firstTargetPort), args));
-//                scope.add(stm);
-//
-//                handleError(scope, new CallContext(createFunctionName(FmiFunctionType.GET, firstTargetPort), args));
-//
-//                if (builder.getSettings().setGetDerivatives && type.equals(new ARealNumericPrimitiveType())) {
-//                    derivativePortsToShare = getDerivatives(e.getValue(), scope);
-//                }
-//
-//                for (int i = 0; i < e.getValue().size(); i++) {
-//                    results.put(e.getValue().get(i), (VariableFmi2Api<V>) valBuf.items().get(i));
-//                }
-//            }
-//            return results;
-        }
+    }
 
 
     @Override
-    public FmiBuilder.DoubleVariable<PStm> getClockShift(FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm> port) {
-        return null;
+    public Map<? extends FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm>, ? extends FmiBuilder.DoubleVariable<PStm>> getClockShift(
+            FmiBuilder.Scope<PStm> scope, FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm>... ports) {
+
+        this.clocksUtil.updateClockShifts(scope, getValueReferenceBuffer(), ports);
+        return Map.of();
+    }
+
+    @Override
+    public void setClockInterval(FmiBuilder.Scope<PStm> scope, FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm> port,
+                                 FmiBuilder.DoubleExpressionValue value) {
+        ArrayVariableFmi2Api<Object> vrefBuf = getValueReferenceBuffer();
+//        vrefBuf.items().getFirst().setValue(port.getPortReferenceValue());
+        PStateDesignator designator = vrefBuf.items().getFirst().getDesignator().clone();
+        scope.add(newAAssignmentStm(designator, newAIntLiteralExp(port.getPortReferenceValue().intValue())));
+        var values=        getClocksUtil().getIntervalBuffer();
+        values.setValue(IntExpressionValue.of(0),value);
+        fmiCall(scope, "setIntervalDecimal", vrefBuf.getReferenceExp().clone(), new AIntLiteralExp(null,1).clone(),
+                values.getExp().clone());
+    }
+
+    @Override
+    public void setClockShift(FmiBuilder.Scope<PStm> scope, FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm> port,
+                              FmiBuilder.DoubleExpressionValue value) {
+        ArrayVariableFmi2Api<Object> vrefBuf = getValueReferenceBuffer();
+//        vrefBuf.items().getFirst().setValue(port.getPortReferenceValue());
+        PStateDesignator designator = vrefBuf.items().getFirst().getDesignator().clone();
+        scope.add(newAAssignmentStm(designator, newAIntLiteralExp(port.getPortReferenceValue().intValue())));
+var values=        getClocksUtil().getShiftBuffer();
+values.setValue(IntExpressionValue.of(0),value);
+        fmiCall(scope, "setShiftDecimal", vrefBuf.getReferenceExp().clone(), new AIntLiteralExp(null,1).clone(),
+                values.getExp().clone());
     }
 
     @Override
@@ -1348,7 +1377,7 @@ this.clocksUtil.updateClockIntervals(scope,getValueReferenceBuffer(),ports);
         // Group by the string value of the port type as grouping by the port type itself doesnt utilise equals
         values.entrySet().stream().collect(Collectors.groupingBy(map -> ((PortFmi3Api) map.getKey()).getType().toString())).entrySet().stream()
                 .forEach(map -> {
-                    PType type = ((PortFmi3Api) map.getValue().get(0).getKey()).getType();
+                    PType type = ((PortFmi3Api) map.getValue().getFirst().getKey()).getType();
 
 
                     Map<FmiBuilder.Port<Fmi3ModelDescription.Fmi3ScalarVariable, PStm>, FmiBuilder.Variable> data =
@@ -1364,7 +1393,7 @@ this.clocksUtil.updateClockIntervals(scope,getValueReferenceBuffer(),ports);
                                 if (port.getSharedAsVariable() == null) {
                                     ArrayVariableFmi2Api<Object> newBuf = this.buffers.growBuffer(Buffers.BufferTypes.Share, buffer, 1, fmiType);
 
-                                    VariableFmi2Api<Object> newShared = newBuf.items().get(newBuf.items().size() - 1);
+                                    VariableFmi2Api<Object> newShared = newBuf.items().getLast();
                                     port.setSharedAsVariable(newShared);
                                 }
 
@@ -1388,7 +1417,7 @@ this.clocksUtil.updateClockIntervals(scope,getValueReferenceBuffer(),ports);
                                             ArrayVariableFmi2Api<Object> sharedDerBuf = growSharedDerBuf(1);
 
                                             ArrayVariableFmi2Api newSharedArray =
-                                                    (ArrayVariableFmi2Api) sharedDerBuf.items().get(sharedDerBuf.items().size() - 1);
+                                                    (ArrayVariableFmi2Api) sharedDerBuf.items().getLast();
                                             derivativePort.setSharedAsVariable(newSharedArray);
                                         }
 
@@ -1496,7 +1525,7 @@ this.clocksUtil.updateClockIntervals(scope,getValueReferenceBuffer(),ports);
                 call(this.getReferenceExp().clone(), "getState", Collections.singletonList(newARefExp(state.getReferenceExp().clone()))));
         scope.add(stm);
         if (builder.getSettings().fmiErrorHandlingEnabled) {
-            FmiStatusErrorHandlingBuilder.generate(builder, this, (IMablScope) scope, new CallContext("getState", null), MablApiBuilder.Fmi3Status.FMI_ERROR,
+            FmiStatusErrorHandlingBuilder.generate(builder, builder.getSettings().fmiErrorHandlingDetailEnabled,this, (IMablScope) scope, new CallContext("getState", null), MablApiBuilder.Fmi3Status.FMI_ERROR,
                     MablApiBuilder.Fmi3Status.FMI_FATAL);
         }
 
@@ -1508,7 +1537,7 @@ this.clocksUtil.updateClockIntervals(scope,getValueReferenceBuffer(),ports);
     }
 
     public List<PortFmi3Api> getAllConnectedOutputs() {
-        return this.ports.stream().filter(x -> x.scalarVariable.getVariable().getCausality() == Fmi3Causality.Output && x.getTargetPorts().size() > 0)
+        return this.ports.stream().filter(x -> x.scalarVariable.getVariable().getCausality() == Fmi3Causality.Output && !x.getTargetPorts().isEmpty())
                 .collect(Collectors.toList());
     }
 
@@ -1530,12 +1559,13 @@ this.clocksUtil.updateClockIntervals(scope,getValueReferenceBuffer(),ports);
     /**
      * Error and Fatal should lead to freeInstance calls followed by subsequent termination.
      */
-    static record CallContext(String name, List<PExp> args) {
+    record CallContext(String name, List<PExp> args) {
     }
 
     static class FmiStatusErrorHandlingBuilder {
 
-        static void generate(MablApiBuilder builder, InstanceVariableFmi3Api instance, IMablScope scope, CallContext callContext,
+        @SuppressWarnings("deprecation")
+        static void generate(MablApiBuilder builder, boolean includeDetails, InstanceVariableFmi3Api instance, IMablScope scope, CallContext callContext,
                              MablApiBuilder.Fmi3Status... statusesToFail) {
             if (statusesToFail == null || statusesToFail.length == 0) {
                 return;
@@ -1555,17 +1585,19 @@ this.clocksUtil.updateClockIntervals(scope,getValueReferenceBuffer(),ports);
             ScopeFmi2Api thenScope = scope.enterIf(new PredicateFmi2Api(exp)).enterThen();
 
             // thenScope.add(newAAssignmentStm(builder.getGlobalExecutionContinue().getDesignator().clone(), newABoolLiteralExp(false)));
-
-            for (MablApiBuilder.Fmi3Status status : statusesToFail) {
-                ScopeFmi2Api s = thenScope.enterIf(new PredicateFmi2Api(checkStatusEq.apply(status))).enterThen();
-                if (Stream.of("get", "set").anyMatch(
-                        p -> Fmi3TypeEnum.getEntries().stream().anyMatch(t -> method.startsWith(p + t.name().substring(0, t.name().indexOf("Type")))))) {
-                    //we have FMI get/set with vr and nvr
-                    builder.getLogger()
-                            .logFmiCallVRefs(s, callContext.args().get(0).clone(),callContext.args().get(1).clone(),method.substring(0, 1).toUpperCase() + method.substring(1) + " failed on '%s' with status: " + status, instance);
-                } else {
-                    builder.getLogger()
-                            .error(s, method.substring(0, 1).toUpperCase() + method.substring(1) + " failed on '%s' with status: " + status, instance);
+            if (includeDetails) {
+                for (MablApiBuilder.Fmi3Status status : statusesToFail) {
+                    ScopeFmi2Api s = thenScope.enterIf(new PredicateFmi2Api(checkStatusEq.apply(status))).enterThen();
+                    if (Stream.of("get", "set").anyMatch(
+                            p -> Fmi3TypeEnum.getEntries().stream().anyMatch(t -> method.startsWith(p + t.name().substring(0, t.name().indexOf("Type")))))) {
+                        //we have FMI get/set with vr and nvr
+                        builder.getLogger()
+                                .logFmiCallVRefs(s, callContext.args().get(0).clone(), callContext.args().get(1).clone(),
+                                        method.substring(0, 1).toUpperCase() + method.substring(1) + " failed on '%s' with status: " + status, instance);
+                    } else {
+                        builder.getLogger()
+                                .error(s, method.substring(0, 1).toUpperCase() + method.substring(1) + " failed on '%s' with status: " + status, instance);
+                    }
                 }
             }
 

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/InstanceVariableFmi3Api.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/InstanceVariableFmi3Api.java
@@ -24,10 +24,8 @@ import org.slf4j.LoggerFactory;
 import javax.xml.xpath.XPathExpressionException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -55,11 +53,12 @@ public class InstanceVariableFmi3Api extends VariableFmi2Api<FmiBuilder.NamedVar
 
     public static final Predicate<InstanceVariableFmi3Api> hasEventMode = instance -> {
         try {
-            return instance.getModelDescription().getHasEventMode();
+            return instance.getModelDescription().getHasEventMode()|| instance.getModelDescription().getModelVariables().stream().anyMatch(v->v.getTypeIdentifier()== Fmi3TypeEnum.ClockType);
         } catch (XPathExpressionException e) {
             throw new RuntimeException(e);
         }
     };
+
 
     static ARefExp wrapAsRef(PExp exp) {
         return new ARefExp(new LexLocation(exp.getLocation()), exp.clone());

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/StateMablVariableFmi3Api.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/StateMablVariableFmi3Api.java
@@ -38,7 +38,7 @@ public class StateMablVariableFmi3Api extends VariableFmi2Api<Object> implements
         scope.add(stm);
         if (builder.getSettings().fmiErrorHandlingEnabled) {
             InstanceVariableFmi3Api.FmiStatusErrorHandlingBuilder
-                    .generate(builder, this.owner, (IMablScope) scope,new InstanceVariableFmi3Api.CallContext("setState",null), MablApiBuilder.Fmi3Status.FMI_ERROR,
+                    .generate(builder, builder.getSettings().fmiErrorHandlingDetailEnabled,this.owner, (IMablScope) scope,new InstanceVariableFmi3Api.CallContext("setState",null), MablApiBuilder.Fmi3Status.FMI_ERROR,
                             MablApiBuilder.Fmi3Status.FMI_FATAL);
         }
     }
@@ -59,7 +59,7 @@ public class StateMablVariableFmi3Api extends VariableFmi2Api<Object> implements
         scope.add(stm);
         if (builder.getSettings().fmiErrorHandlingEnabled) {
             InstanceVariableFmi3Api.FmiStatusErrorHandlingBuilder
-                    .generate(builder,  this.owner, (IMablScope) scope,new InstanceVariableFmi3Api.CallContext("freeState",null), MablApiBuilder.Fmi3Status.FMI_ERROR,
+                    .generate(builder, builder.getSettings().fmiErrorHandlingDetailEnabled, this.owner, (IMablScope) scope,new InstanceVariableFmi3Api.CallContext("freeState",null), MablApiBuilder.Fmi3Status.FMI_ERROR,
                             MablApiBuilder.Fmi3Status.FMI_FATAL);
         }
 

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/StateMablVariableFmi3Api.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/StateMablVariableFmi3Api.java
@@ -38,7 +38,7 @@ public class StateMablVariableFmi3Api extends VariableFmi2Api<Object> implements
         scope.add(stm);
         if (builder.getSettings().fmiErrorHandlingEnabled) {
             InstanceVariableFmi3Api.FmiStatusErrorHandlingBuilder
-                    .generate(builder, "setState", this.owner, (IMablScope) scope, MablApiBuilder.Fmi3Status.FMI_ERROR,
+                    .generate(builder, this.owner, (IMablScope) scope,new InstanceVariableFmi3Api.CallContext("setState",null), MablApiBuilder.Fmi3Status.FMI_ERROR,
                             MablApiBuilder.Fmi3Status.FMI_FATAL);
         }
     }
@@ -59,7 +59,7 @@ public class StateMablVariableFmi3Api extends VariableFmi2Api<Object> implements
         scope.add(stm);
         if (builder.getSettings().fmiErrorHandlingEnabled) {
             InstanceVariableFmi3Api.FmiStatusErrorHandlingBuilder
-                    .generate(builder, "freeState", this.owner, (IMablScope) scope, MablApiBuilder.Fmi3Status.FMI_ERROR,
+                    .generate(builder,  this.owner, (IMablScope) scope,new InstanceVariableFmi3Api.CallContext("freeState",null), MablApiBuilder.Fmi3Status.FMI_ERROR,
                             MablApiBuilder.Fmi3Status.FMI_FATAL);
         }
 

--- a/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/VariableFmi2Api.java
+++ b/frameworks/fmi2api/src/main/java/org/intocps/maestro/framework/fmi2/api/mabl/variables/VariableFmi2Api.java
@@ -1,16 +1,14 @@
 package org.intocps.maestro.framework.fmi2.api.mabl.variables;
 
 import org.intocps.maestro.ast.MableAstFactory;
-import org.intocps.maestro.ast.node.PExp;
-import org.intocps.maestro.ast.node.PStateDesignator;
-import org.intocps.maestro.ast.node.PStm;
-import org.intocps.maestro.ast.node.PType;
+import org.intocps.maestro.ast.node.*;
 import org.intocps.maestro.framework.fmi2.api.FmiBuilder;
 import org.intocps.maestro.framework.fmi2.api.mabl.BuilderUtil;
 import org.intocps.maestro.framework.fmi2.api.mabl.NumericExpressionValueFmi2Api;
 import org.intocps.maestro.framework.fmi2.api.mabl.scoping.IMablScope;
 import org.intocps.maestro.framework.fmi2.api.mabl.values.DoubleExpressionValue;
 import org.intocps.maestro.framework.fmi2.api.mabl.values.IntExpressionValue;
+import org.intocps.maestro.typechecker.TypeComparator;
 
 import static org.intocps.maestro.ast.MableAstFactory.newAAssignmentStm;
 
@@ -118,10 +116,12 @@ public class VariableFmi2Api<V> implements FmiBuilder.Variable<PStm, V>, Indexed
 
 
     public NumericExpressionValueFmi2Api toMath() {
-        if (this instanceof DoubleVariableFmi2Api) {
-            return new DoubleExpressionValue(this.getExp());
-        } else if (this instanceof IntVariableFmi2Api) {
-            return new IntExpressionValue(this.getExp());
+
+
+        if (new TypeComparator().compatible(ARealNumericPrimitiveType.class, this.getType())) {
+            return new DoubleExpressionValue(this.getExp().clone());
+        } else if (new TypeComparator().compatible(SNumericPrimitiveType.class, this.getType())) {
+            return new IntExpressionValue(this.getExp().clone());
         } else {
             throw new RuntimeException("Variable is not of Numeric Type but of type: " + this.getClass());
         }

--- a/frameworks/fmi2api/src/test/java/org/intocps/maestro/framework/fmi2/api/mabl/ComponentVariableFmi2ApiTest.java
+++ b/frameworks/fmi2api/src/test/java/org/intocps/maestro/framework/fmi2/api/mabl/ComponentVariableFmi2ApiTest.java
@@ -71,7 +71,7 @@ public class ComponentVariableFmi2ApiTest extends BaseApiAssertTest {
 
         MablApiBuilder.MablSettings settings = new MablApiBuilder.MablSettings();
         settings.fmiErrorHandlingEnabled = false;
-        MablApiBuilder builder = new MablApiBuilder(settings, null);
+        MablApiBuilder builder = new MablApiBuilder(settings);
         DynamicActiveBuilderScope dynamicScope = builder.getDynamicScope();
 
         FmuVariableFmi2Api tankFMU =

--- a/interpreter/src/main/java/org/intocps/maestro/interpreter/Interpreter.java
+++ b/interpreter/src/main/java/org/intocps/maestro/interpreter/Interpreter.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class Interpreter extends QuestionAnswerAdaptor<Context, Value> {
 
@@ -380,7 +381,10 @@ public class Interpreter extends QuestionAnswerAdaptor<Context, Value> {
         if (node.getObject() != null) {
             Value v = node.getObject().apply(this, question).deref();
             if (v instanceof NullValue) {
-                logger.error("The target object: \"" + node.getObject().toString() + "\" is null. Related call: \"" + node.toString() + "\"");
+                logger.error("The target object: \"" + node.getObject().toString() + "\" is null. Related call: \"" + node + "\"");
+                throw new InterpreterException("Unhandled node: " + node);
+            }else if(!(v instanceof ModuleValue)){
+                logger.error("The target object: \"" + node.getObject().toString() + "\" is not a module. Related call: \"" + node + "\"");
                 throw new InterpreterException("Unhandled node: " + node);
             } else {
                 ModuleValue objectModule = (ModuleValue) v;
@@ -648,6 +652,34 @@ public class Interpreter extends QuestionAnswerAdaptor<Context, Value> {
     @Override
     public Value caseATransferAsStm(ATransferAsStm node, Context question) {
         //this has no semantic meaning during normal execution
+        return new VoidValue();
+    }
+
+    @Override
+    public Value caseADebugStm(ADebugStm node, Context question) throws AnalysisException {
+
+        var tokens = node.getTokens()==null?Collections.emptyList():node.getTokens().stream().map(AStringLiteralExp::getValue).toList();
+        if(tokens.contains("context"))
+        {
+            Context ctxt= question;
+            Stack<Context> stack = new Stack<>();
+            stack.push(ctxt);
+            while((ctxt=ctxt.outer)!=null){stack.push(ctxt);}
+            StringBuilder sb = new StringBuilder();
+            sb.append("Context stack:\n");
+            while(!stack.isEmpty()){
+                var depth = stack.size();
+                var frame = stack.pop();
+                var prefix = Stream.generate(() -> "\t").limit(depth-1).collect(Collectors.joining());
+                for(var entry:frame.values.entrySet())
+                {
+                    sb.append(prefix).append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
+                }
+            }
+
+            logger.info(sb.toString());
+        }
+
         return new VoidValue();
     }
 

--- a/interpreter/src/main/java/org/intocps/maestro/interpreter/Interpreter.java
+++ b/interpreter/src/main/java/org/intocps/maestro/interpreter/Interpreter.java
@@ -396,7 +396,7 @@ public class Interpreter extends QuestionAnswerAdaptor<Context, Value> {
             } catch (InterpreterTransitionException te) {
                 throw te;
             } catch (Exception e) {
-                throw new InterpreterException("Unable to evaluate node: " + node, e);
+                throw new InterpreterException("Unable to evaluate node: " + node + " at "+node.getLocation(), e);
             }
         }
 
@@ -446,6 +446,8 @@ public class Interpreter extends QuestionAnswerAdaptor<Context, Value> {
             } else {
                 message = msg.toString();
             }
+
+            message +=" \""+node.getExp().getLocation().toString()+"\"";
         }
 
         throw new ErrorException(message);

--- a/interpreter/src/main/java/org/intocps/maestro/interpreter/Interpreter.java
+++ b/interpreter/src/main/java/org/intocps/maestro/interpreter/Interpreter.java
@@ -73,7 +73,7 @@ public class Interpreter extends QuestionAnswerAdaptor<Context, Value> {
 
     @Override
     public Value caseASimulationSpecificationCompilationUnit(ASimulationSpecificationCompilationUnit node,
-            Context question) throws AnalysisException {
+                                                             Context question) throws AnalysisException {
         return node.getBody().apply(this, question);
 
     }
@@ -383,7 +383,7 @@ public class Interpreter extends QuestionAnswerAdaptor<Context, Value> {
             if (v instanceof NullValue) {
                 logger.error("The target object: \"" + node.getObject().toString() + "\" is null. Related call: \"" + node + "\"");
                 throw new InterpreterException("Unhandled node: " + node);
-            }else if(!(v instanceof ModuleValue)){
+            } else if (!(v instanceof ModuleValue)) {
                 logger.error("The target object: \"" + node.getObject().toString() + "\" is not a module. Related call: \"" + node + "\"");
                 throw new InterpreterException("Unhandled node: " + node);
             } else {
@@ -400,7 +400,7 @@ public class Interpreter extends QuestionAnswerAdaptor<Context, Value> {
             } catch (InterpreterTransitionException te) {
                 throw te;
             } catch (Exception e) {
-                throw new InterpreterException("Unable to evaluate node: " + node + " at "+node.getLocation(), e);
+                throw new InterpreterException("Unable to evaluate node: " + node + " at " + node.getLocation(), e);
             }
         }
 
@@ -451,7 +451,7 @@ public class Interpreter extends QuestionAnswerAdaptor<Context, Value> {
                 message = msg.toString();
             }
 
-            message +=" \""+node.getExp().getLocation().toString()+"\"";
+            message += " \"" + node.getExp().getLocation().toString() + "\"";
         }
 
         throw new ErrorException(message);
@@ -658,22 +658,31 @@ public class Interpreter extends QuestionAnswerAdaptor<Context, Value> {
     @Override
     public Value caseADebugStm(ADebugStm node, Context question) throws AnalysisException {
 
-        var tokens = node.getTokens()==null?Collections.emptyList():node.getTokens().stream().map(AStringLiteralExp::getValue).toList();
-        if(tokens.contains("context"))
-        {
-            Context ctxt= question;
+        var tokens = node.getTokens() == null ? Collections.emptyList() : node.getTokens().stream().map(AStringLiteralExp::getValue).toList();
+        if (tokens.contains("context")) {
+            Context ctxt = question;
             Stack<Context> stack = new Stack<>();
             stack.push(ctxt);
-            while((ctxt=ctxt.outer)!=null){stack.push(ctxt);}
+            while ((ctxt = ctxt.outer) != null) {
+                stack.push(ctxt);
+            }
             StringBuilder sb = new StringBuilder();
             sb.append("Context stack:\n");
-            while(!stack.isEmpty()){
-                var depth = stack.size();
-                var frame = stack.pop();
-                var prefix = Stream.generate(() -> "\t").limit(depth-1).collect(Collectors.joining());
-                for(var entry:frame.values.entrySet())
+            int depth = 0;
+            for (var frame : stack.reversed()) {
+                var prefix = Stream.generate(() -> "\t").limit(depth++).collect(Collectors.joining());
+                if (depth > 1) {
+                    sb.append("\n");
+                }
+                sb.append(prefix).append("## Context depth: ").append(depth).append(" ##\n");
+                if(frame.values.isEmpty())
                 {
-                    sb.append(prefix).append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
+                    sb.append(prefix).append("\t").append("-- empty --").append("\n");
+                }
+                for (var entry : frame.values.entrySet().stream()
+                        .sorted(Comparator.comparing(e -> e.getKey().getText()))
+                        .toList()) {
+                    sb.append(prefix).append("\t").append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
                 }
             }
 

--- a/interpreter/src/main/java/org/intocps/maestro/interpreter/extensions/fmi3/Fmi3Interpreter.java
+++ b/interpreter/src/main/java/org/intocps/maestro/interpreter/extensions/fmi3/Fmi3Interpreter.java
@@ -85,7 +85,7 @@ public class Fmi3Interpreter {
 
     static long[] subRang(Value arrayValue, Value lengthValue) {
         long[] vrefs = (long[]) longArrayInArgMapper.map(arrayValue);
-        int length = ((NumericValue) lengthValue).intValue();
+        int length = ((NumericValue) lengthValue.deref()).intValue();
 
         return
                 Arrays.copyOfRange(vrefs, 0, length);

--- a/interpreter/src/main/java/org/intocps/maestro/interpreter/extensions/fmi3/Fmi3Interpreter.java
+++ b/interpreter/src/main/java/org/intocps/maestro/interpreter/extensions/fmi3/Fmi3Interpreter.java
@@ -443,7 +443,7 @@ FMI2Component instantiateCoSimulationWrapAsFmi2(string instanceName, string inst
 
             checkArgLength(fcargs, 3);
             try {
-                FmuResult<double[]> res = instance.getShiftDecimal((long[]) longArrayInArgMapper.map(fcargs.get(0)));
+                FmuResult<double[]> res = instance.getShiftDecimal(subRang(fcargs.get(0),fcargs.get(1)));
                 doubleArrayOutArgMapper.mapOut(fcargs.get(2), res.result);
                 return status2IntValue(res.status);
             } catch (FmuInvocationException e) {
@@ -456,7 +456,7 @@ FMI2Component instantiateCoSimulationWrapAsFmi2(string instanceName, string inst
 
             checkArgLength(fcargs, 4);
             try {
-                FmuResult<IFmi3Instance.GetShiftFractionResponse> res = instance.getShiftFraction((long[]) longArrayInArgMapper.map(fcargs.get(0)));
+                FmuResult<IFmi3Instance.GetShiftFractionResponse> res = instance.getShiftFraction(subRang(fcargs.get(0),fcargs.get(1)));
                 uintArrayOutArgMapper.mapOut(fcargs.get(2), res.result.getShiftCounters());
                 uintArrayOutArgMapper.mapOut(fcargs.get(3), res.result.getResolutions());
                 return status2IntValue(res.status);

--- a/interpreter/src/main/java/org/intocps/maestro/interpreter/extensions/fmi3/Fmi3Interpreter.java
+++ b/interpreter/src/main/java/org/intocps/maestro/interpreter/extensions/fmi3/Fmi3Interpreter.java
@@ -83,6 +83,14 @@ public class Fmi3Interpreter {
     static final ExternalReflectCallHelper.ArgMapping doubleOutArgMapper = new ExternalReflectCallHelper.ArgMapping(TP.Real, 1,
             ExternalReflectCallHelper.ArgMapping.InOut.Output, null);
 
+    static long[] subRang(Value arrayValue, Value lengthValue) {
+        long[] vrefs = (long[]) longArrayInArgMapper.map(arrayValue);
+        int length = ((NumericValue) lengthValue).intValue();
+
+        return
+                Arrays.copyOfRange(vrefs, 0, length);
+    }
+
     final static Logger logger = LoggerFactory.getLogger(Interpreter.class);
     private final File workingDirectory;
     private final Function<String, AModuleDeclaration> resolver;
@@ -163,7 +171,7 @@ FMI2Component instantiateCoSimulationWrapAsFmi2(string instanceName, string inst
                 Layout layout = PatternLayout.newBuilder().withPattern(pattern).withCharset(StandardCharsets.UTF_8).build();//
 
                 ILogMessageCallback logCallback = (instanceName, status, category, message) -> {
-                    logger.info("{} {} {} {}",category, status, instanceName , message);
+                    logger.info("{} {} {} {}", category, status, instanceName, message);
                     //logger.info("NATIVE: instance: '{}', status: '{}', category: '{}', message: {}", instanceName, status, category, message);
                     {
 
@@ -210,7 +218,7 @@ FMI2Component instantiateCoSimulationWrapAsFmi2(string instanceName, string inst
                     return new NullValue();
                 }
                 long stopInstantiateTime = System.nanoTime();
-                logger.info("Interpretation instantiate took: {}" , (stopInstantiateTime - startInstantiateTime));
+                logger.info("Interpretation instantiate took: {}", (stopInstantiateTime - startInstantiateTime));
 
                 return getFmuInstanceValue(fmuLogOutputStream, instance, name, resolver);
 
@@ -279,7 +287,7 @@ FMI2Component instantiateCoSimulationWrapAsFmi2(string instanceName, string inst
     static boolean checkRequiredFunctions(AModuleDeclaration module, Map<String, Value> functions) {
         var expectedFunctions = module.getFunctions().stream().map(f -> f.getName().getText()).collect(Collectors.toSet());
 
-        var missingFunctions=expectedFunctions.stream().filter(f->!functions.containsKey(f)).collect(Collectors.toList());
+        var missingFunctions = expectedFunctions.stream().filter(f -> !functions.containsKey(f)).collect(Collectors.toList());
 
         if (!missingFunctions.isEmpty()) {
             logger.warn("Runtime type '{}' does not match declaration. Missing: '{}'", module.getName().getText(),
@@ -462,7 +470,8 @@ FMI2Component instantiateCoSimulationWrapAsFmi2(string instanceName, string inst
             //              out uint elementIndicesOfIndependents[], out int dependencyKinds[], int nDependencies);
             checkArgLength(fcargs, 6);
             try {
-                FmuResult<IFmi3Instance.VariableDependency> res = instance.getVariableDependencies((long) longInArgMapper.map(fcargs.get(0)), (long) intInArgMapper.map(fcargs.get(5)));
+                FmuResult<IFmi3Instance.VariableDependency> res = instance.getVariableDependencies((long) longInArgMapper.map(fcargs.get(0)),
+                        (long) intInArgMapper.map(fcargs.get(5)));
                 intArrayOutArgMapper.mapOut(fcargs.get(1), res.result.getElementIndicesOfDependent());
                 longArrayOutArgMapper.mapOut(fcargs.get(2), res.result.getIndependents());
                 longArrayOutArgMapper.mapOut(fcargs.get(3), res.result.getElementIndicesOfIndependents());
@@ -499,7 +508,8 @@ FMI2Component instantiateCoSimulationWrapAsFmi2(string instanceName, string inst
 //            int setIntervalDecimal(uint valueReferences[], int nValueReferences, real interval[]);
             checkArgLength(fcargs, 3);
             try {
-                Fmi3Status res = instance.setIntervalDecimal((long[]) longArrayInArgMapper.map(fcargs.get(0)), (double[]) doubleArrayInArgMapper.map(fcargs.get(2)));
+                Fmi3Status res = instance.setIntervalDecimal((long[]) longArrayInArgMapper.map(fcargs.get(0)),
+                        (double[]) doubleArrayInArgMapper.map(fcargs.get(2)));
                 return new IntegerValue(res.value);
             } catch (FmuInvocationException e) {
                 throw new InterpreterException(e);
@@ -558,7 +568,7 @@ FMI2Component instantiateCoSimulationWrapAsFmi2(string instanceName, string inst
 
             checkArgLength(fcargs, 3);
             try {
-                FmuResult<boolean[]> res = instance.getClock((long[]) longArrayInArgMapper.map(fcargs.get(0)));
+                FmuResult<boolean[]> res = instance.getClock(subRang(fcargs.get(0),fcargs.get(1)));
                 boolArrayOutArgMapper.mapOut(fcargs.get(2), res.result);
                 return status2IntValue(res.status);
             } catch (FmuInvocationException e) {
@@ -634,10 +644,11 @@ FMI2Component instantiateCoSimulationWrapAsFmi2(string instanceName, string inst
 
             checkArgLength(fcargs, 4);
             try {
+
                 FmuResult<IFmi3Instance.GetIntervalDecimalResponse> res = instance.getIntervalDecimal(
-                        (long[]) longArrayInArgMapper.map(fcargs.get(0)));
+                        subRang(fcargs.get(0),fcargs.get(1)));
                 doubleArrayOutArgMapper.mapOut(fcargs.get(2), res.result.getIntervals());
-                doubleArrayOutArgMapper.mapOut(fcargs.get(3), res.result.getQualifiers());
+                intArrayOutArgMapper.mapOut(fcargs.get(3), Arrays.stream(res.result.getQualifiers()).mapToInt(Fmi3IntervalQualifier::getValue).toArray());
                 return status2IntValue(res.status);
             } catch (FmuInvocationException e) {
                 throw new InterpreterException(e);
@@ -652,7 +663,7 @@ FMI2Component instantiateCoSimulationWrapAsFmi2(string instanceName, string inst
             checkArgLength(fcargs, 5);
             try {
                 FmuResult<IFmi3Instance.IntervalFractionResponse> res = instance.getIntervalFraction(
-                        (long[]) longArrayInArgMapper.map(fcargs.get(0)));
+                        subRang(fcargs.get(0),fcargs.get(1)));
                 uintArrayOutArgMapper.mapOut(fcargs.get(2), res.result.getIntervalCounters());
                 uintArrayOutArgMapper.mapOut(fcargs.get(3), res.result.getResolutions());
                 intInArgMapper.mapOut(fcargs.get(3), Arrays.stream(res.result.getQualifiers()).map(q -> q.getValue()).toArray());
@@ -700,8 +711,8 @@ FMI2Component instantiateCoSimulationWrapAsFmi2(string instanceName, string inst
                 final ExternalReflectCallHelper.ArgMapping uintOutArgMapper = new ExternalReflectCallHelper.ArgMapping(TP.Long, 1,
                         ExternalReflectCallHelper.ArgMapping.InOut.Output, null);
                 uintOutArgMapper.mapOut(fcargs.get(0), res.result);
-                UpdatableValue v= (UpdatableValue) fcargs.get(0);
-                v.setValue(new UnsignedIntegerValue(((LongValue)v.deref()).getValue()));
+                UpdatableValue v = (UpdatableValue) fcargs.get(0);
+                v.setValue(new UnsignedIntegerValue(((LongValue) v.deref()).getValue()));
                 return status2IntValue(res.status);
             } catch (FmuInvocationException e) {
                 throw new InterpreterException(e);
@@ -878,7 +889,7 @@ FMI2Component instantiateCoSimulationWrapAsFmi2(string instanceName, string inst
         }));
 
 
-        if(!checkRequiredFunctions(module, functions)){
+        if (!checkRequiredFunctions(module, functions)) {
             autobindWarnings.forEach(logger::warn);
         }
 
@@ -909,7 +920,7 @@ FMI2Component instantiateCoSimulationWrapAsFmi2(string instanceName, string inst
             }
             File file = new File(uri);
 
-            final IFmi3Fmu fmu = new Fmu3(file);
+            final IFmi3Fmu fmu = file.isFile() ? new Fmu3(file) : new DirectoryFmi3Fmu(file, file.getName());
 
             fmu.load();
 
@@ -917,7 +928,7 @@ FMI2Component instantiateCoSimulationWrapAsFmi2(string instanceName, string inst
 
             long stopTime = System.nanoTime();
 
-            logger.debug("Interpretation load took: {}" , (stopTime - startExecTime));
+            logger.debug("Interpretation load took: {}", (stopTime - startExecTime));
 
             return new Fmu3Value(functions, fmu);
 

--- a/interpreter/src/main/java/org/intocps/maestro/interpreter/values/LoggerValue.java
+++ b/interpreter/src/main/java/org/intocps/maestro/interpreter/values/LoggerValue.java
@@ -82,6 +82,58 @@ public class LoggerValue extends ExternalModuleValue<Object> {
 
             return new VoidValue();
         }));
+
+        componentMembers.put("logFmiCallVRefs", new FunctionValue.ExternalFunctionValue(fcargs -> {
+
+            if (fcargs == null) {
+                throw new InterpreterException("No values passed");
+            }
+
+            if (fcargs.stream().anyMatch(Objects::isNull)) {
+                throw new InterpreterException("Argument list contains null values");
+            }
+
+            if (fcargs.size() < 4) {
+                throw new InterpreterException("Too few arguments");
+            }
+
+            NumericValue level = (NumericValue) fcargs.get(0).deref();
+
+
+            var vr =(ArrayValue) fcargs.get(1).deref();
+            var nvr =(NumericValue) fcargs.get(2).deref();
+
+           var vnrs = vr.getValues().stream().limit(nvr.intValue()).map(Object::toString).collect(Collectors.joining(","));
+
+            StringValue msg = (StringValue) fcargs.get(3).deref();
+
+            DecimalFormat df = new DecimalFormat("0.00##");
+
+            String logMsg = String.format(msg.getValue(), getValues(fcargs.stream().skip(4).collect(Collectors.toList())));
+
+            logMsg+=". Variable references: "+vnrs;
+            switch (level.intValue()) {
+                case 0:
+                    logger.trace(logMsg);
+                    break;
+                case 1:
+                    logger.debug(logMsg);
+                    break;
+                case 2:
+                    logger.info(logMsg);
+                    break;
+                case 3:
+                    logger.warn(logMsg);
+                    break;
+                case 4:
+                    logger.error(logMsg);
+                    break;
+            }
+
+
+            return new VoidValue();
+        }));
+
         return componentMembers;
     }
 }

--- a/interpreter/src/main/java/org/intocps/maestro/interpreter/values/MathValue.java
+++ b/interpreter/src/main/java/org/intocps/maestro/interpreter/values/MathValue.java
@@ -35,7 +35,7 @@ public class MathValue extends ExternalModuleValue<Object> {
         componentMembers.put("minRealFromArray", new FunctionValue.ExternalFunctionValue(args -> {
 
             if (args.get(0).deref() instanceof ArrayValue) {
-                List<Value> valueArray = ValueExtractionUtilities.getArrayValue(args.get(0), Value.class);
+                List<Value> valueArray = ValueExtractionUtilities.getArrayValue(args.getFirst(), Value.class);
                 if (valueArray.size() < 1) {
                     return new IntegerValue(0);
                 } else if (valueArray.get(0).deref() instanceof RealValue) {

--- a/interpreter/src/test/java/org/intocps/maestro/interpreter/ExternalReflectCallHelperAutoTest.java
+++ b/interpreter/src/test/java/org/intocps/maestro/interpreter/ExternalReflectCallHelperAutoTest.java
@@ -7,6 +7,7 @@ import org.intocps.fmi.jnifmuapi.fmi3.Fmu3;
 import org.intocps.maestro.ast.AEqualBinaryExp;
 import org.intocps.maestro.ast.AFunctionDeclaration;
 import org.intocps.maestro.ast.LexIdentifier;
+import org.intocps.maestro.ast.LexLocation;
 import org.intocps.maestro.ast.analysis.AnalysisException;
 import org.intocps.maestro.ast.node.*;
 import org.intocps.maestro.core.messages.ErrorReporter;
@@ -109,8 +110,8 @@ public class ExternalReflectCallHelperAutoTest {
 
         Interpreter interpreter = new Interpreter(null);
 
-        final AEqualBinaryExp eq = new AEqualBinaryExp(new AIdentifierExp(new LexIdentifier("a", null)),
-                new AIdentifierExp(new LexIdentifier("b", null)));
+        final AEqualBinaryExp eq = new AEqualBinaryExp(new LexLocation("d",1,1),new AIdentifierExp(new LexLocation("d",1,1),new LexIdentifier("a", null)),
+                new AIdentifierExp(new LexLocation("d",1,1),new LexIdentifier("b", null)));
         for (AFunctionDeclaration f : functions) {
             ExternalReflectCallHelper helper = new ExternalReflectCallHelper(f, this);
             System.out.println(helper);
@@ -126,12 +127,12 @@ public class ExternalReflectCallHelperAutoTest {
                     Value a = (Value) args.get(i).as(UpdatableValue.class).deref().as(ArrayValue.class).getValues().get(0);
                     Value b = (Value) argsRef.get(i).as(UpdatableValue.class).deref().as(ArrayValue.class).getValues().get(0);
                     Context c = new Context(null);
-                    c.put(new AIdentifierExp(new LexIdentifier("a", null)), a);
-                    c.put(new AIdentifierExp(new LexIdentifier("b", null)), b);
+                    c.put(new AIdentifierExp(new LexLocation("d",1,1),new LexIdentifier("a", null)), a);
+                    c.put(new AIdentifierExp(new LexLocation("d",1,1),new LexIdentifier("b", null)), b);
                     Assertions.assertFalse(((BooleanValue) interpreter.caseAEqualBinaryExp(eq, c)).getValue(), "value should have changed");
 
-                    c.put(new AIdentifierExp(new LexIdentifier("a", null)), b);
-                    c.put(new AIdentifierExp(new LexIdentifier("b", null)), b);
+                    c.put(new AIdentifierExp(new LexLocation("d",1,1),new LexIdentifier("a", null)), b);
+                    c.put(new AIdentifierExp(new LexLocation("d",1,1),new LexIdentifier("b", null)), b);
                     Assertions.assertTrue(((BooleanValue) interpreter.caseAEqualBinaryExp(eq, c)).getValue(), "value should not have changed");
 
 

--- a/maestro/src/main/java/org/intocps/maestro/BuilderHelper.java
+++ b/maestro/src/main/java/org/intocps/maestro/BuilderHelper.java
@@ -2,6 +2,7 @@ package org.intocps.maestro;
 
 import org.intocps.maestro.ast.AVariableDeclaration;
 import org.intocps.maestro.ast.LexIdentifier;
+import org.intocps.maestro.ast.LexLocation;
 import org.intocps.maestro.ast.analysis.AnalysisException;
 import org.intocps.maestro.ast.analysis.DepthFirstAnalysisAdaptorQuestion;
 import org.intocps.maestro.ast.node.*;
@@ -130,7 +131,7 @@ public class BuilderHelper {
 
                             return new FmuVariableFmi2Api(instance.getOwnerIdentifier(), builder, mdc, dummyStm, newANameType("FMI2"),
                                     builder.getDynamicScope().getActiveScope(), builder.getDynamicScope(), null,
-                                    new AIdentifierExp(new LexIdentifier(instance.getOwnerIdentifier().replace("{", "").replace("}", ""), null)));
+                                    new AIdentifierExp(new LexLocation("",0,0),new LexIdentifier(instance.getOwnerIdentifier().replace("{", "").replace("}", ""), null)));
 
                         } catch (IllegalAccessException | XPathExpressionException | InvocationTargetException e) {
                             throw new RuntimeException(e);
@@ -142,7 +143,7 @@ public class BuilderHelper {
 
                             return new FmuVariableFmi3Api(instance.getOwnerIdentifier(), builder, mdc, dummyStm, newANameType("FMI3"),
                                     builder.getDynamicScope().getActiveScope(), builder.getDynamicScope(), null,
-                                    new AIdentifierExp(new LexIdentifier(instance.getOwnerIdentifier().replace("{", "").replace("}", ""), null)));
+                                    new AIdentifierExp(new LexLocation("",0,0),new LexIdentifier(instance.getOwnerIdentifier().replace("{", "").replace("}", ""), null)));
                         } catch (IllegalAccessException | XPathExpressionException | InvocationTargetException e) {
                             throw new RuntimeException(e);
                         }

--- a/maestro/src/main/java/org/intocps/maestro/BuilderHelper.java
+++ b/maestro/src/main/java/org/intocps/maestro/BuilderHelper.java
@@ -12,10 +12,7 @@ import org.intocps.maestro.framework.fmi2.ComponentInfo;
 import org.intocps.maestro.framework.fmi2.Fmi2SimulationEnvironment;
 import org.intocps.maestro.framework.fmi2.InstanceInfo;
 import org.intocps.maestro.framework.fmi2.api.FmiBuilder;
-import org.intocps.maestro.framework.fmi2.api.mabl.FromMaBLToMaBLAPI;
-import org.intocps.maestro.framework.fmi2.api.mabl.MablApiBuilder;
-import org.intocps.maestro.framework.fmi2.api.mabl.ModelDescriptionContext;
-import org.intocps.maestro.framework.fmi2.api.mabl.ModelDescriptionContext3;
+import org.intocps.maestro.framework.fmi2.api.mabl.*;
 import org.intocps.maestro.framework.fmi2.api.mabl.variables.*;
 import org.intocps.maestro.typechecker.TypeComparator;
 import org.jgrapht.graph.DefaultDirectedGraph;
@@ -40,7 +37,7 @@ public class BuilderHelper {
 
         MablApiBuilder.MablSettings settings = new MablApiBuilder.MablSettings();
         settings.fmiErrorHandlingEnabled = true;
-        this.builder = new MablApiBuilder(settings, callToBeReplaced);
+        this.builder = new ExpansionMableApiBuilder(settings, callToBeReplaced);
 
         // Build a graph from AInstanceMapping. I.e. if FMU instance A is faultinjected by B then the graph should be
         // B -> A

--- a/maestro/src/main/java/org/intocps/maestro/MablSpecificationGenerator.java
+++ b/maestro/src/main/java/org/intocps/maestro/MablSpecificationGenerator.java
@@ -278,6 +278,7 @@ public class MablSpecificationGenerator {
             }
 
         } catch (ExpandException e) {
+            e.printStackTrace();
             logger.error(String.format("Internal error in plug-in '%s' at %s. Message: %s", replacementPlugin.getName(),
                     callToBeReplaced.getMethodName().toString(), e.getMessage()), e);
             reporter.report(999, String.format("Internal error in plug-in '%s' at %s. Message: %s", replacementPlugin.getName(),

--- a/maestro/src/main/java/org/intocps/maestro/cli/ImportCmd.java
+++ b/maestro/src/main/java/org/intocps/maestro/cli/ImportCmd.java
@@ -56,6 +56,8 @@ public class ImportCmd implements Callable<Integer> {
     List<File> fmuSearchPaths;
     @CommandLine.Option(names = {"-i", "--interpret"}, description = "Interpret spec after import")
     boolean interpret;
+    @CommandLine.Option(names = {"-udsp", "--use-dumped-spec-positions"}, description = "Use the position (line) from the dumped spec for interpretation")
+    boolean useDumpedSpecPositions;
     @CommandLine.Parameters(index = "1..*", description = "One or more specification files")
     List<File> files;
     @CommandLine.Option(names = "-output", description = "Path to a directory where the imported spec will be stored")
@@ -112,6 +114,7 @@ public class ImportCmd implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
+        System.out.println(ProcessHandle.current().pid());
 
         if (type == ImportType.Sg1) {
 
@@ -180,7 +183,16 @@ public class ImportCmd implements Callable<Integer> {
         }
 
         if (interpret) {
-            util.interpret();
+            if (useDumpedSpecPositions) {
+                util = new MablCliUtil(output, output, settings);
+                util.setVerbose(verbose);
+                util.parse(List.of(new File(output, "spec.mabl")));
+                if (util.typecheck()) {
+                    util.interpret();
+                }
+            } else {
+                util.interpret();
+            }
         }
         return 0;
     }
@@ -270,15 +282,13 @@ public class ImportCmd implements Callable<Integer> {
             if (graphsNode.isArray()) {
                 for (var graphNode : graphsNode) {
                     if (graphNode.has("livestream")) {
-                    var livestreamNode = graphNode.get("livestream");
+                        var livestreamNode = graphNode.get("livestream");
                         for (Iterator<String> it = livestreamNode.fieldNames(); it.hasNext(); ) {
                             var fieldName = it.next();
                             var listNode = livestreamNode.get(fieldName);
-                            if (listNode.isArray())
-                            {
+                            if (listNode.isArray()) {
                                 var list = new ArrayList<String>();
-                                for(var name : listNode)
-                                {
+                                for (var name : listNode) {
                                     list.add(name.asText());
                                 }
                                 if (!list.isEmpty()) {
@@ -290,7 +300,7 @@ public class ImportCmd implements Callable<Integer> {
                 }
             }
 
-            if(!livestream.isEmpty()) {
+            if (!livestream.isEmpty()) {
                 ((ObjectNode) rootNode).set("livestream", mapper.valueToTree(livestream));
 
             }

--- a/maestro/src/main/java/org/intocps/maestro/cli/ImportCmd.java
+++ b/maestro/src/main/java/org/intocps/maestro/cli/ImportCmd.java
@@ -114,7 +114,6 @@ public class ImportCmd implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        System.out.println(ProcessHandle.current().pid());
 
         if (type == ImportType.Sg1) {
 

--- a/maestro/src/main/java/org/intocps/maestro/template/MaBLTemplateGenerator.java
+++ b/maestro/src/main/java/org/intocps/maestro/template/MaBLTemplateGenerator.java
@@ -12,6 +12,7 @@ import org.intocps.maestro.core.dto.IAlgorithmConfig;
 import org.intocps.maestro.fmi.Fmi2ModelDescription;
 import org.intocps.maestro.fmi.ModelDescription;
 import org.intocps.maestro.fmi.fmi3.Fmi3ModelDescription;
+import org.intocps.maestro.fmi.fmi3.Fmi3TypeEnum;
 import org.intocps.maestro.framework.core.FrameworkUnitInfo;
 import org.intocps.maestro.framework.core.IRelation;
 import org.intocps.maestro.framework.fmi2.*;
@@ -155,11 +156,16 @@ public class MaBLTemplateGenerator {
         } else if (instance.source instanceof InstanceInfo) {
             String requiredIntermediateVariablesLex = instanceLexName + "_requiredIntermediateVariables";
 
-            List<PStm> instantiate = Arrays.asList(newVariable(requiredIntermediateVariablesLex, new AUIntNumericPrimitiveType(), 0),
-                    newAAssignmentStm(newAIdentifierStateDesignator(newAIdentifier(instanceLexName)),
-                            call(fmuLexName, "instantiateCoSimulation", newAStringLiteralExp(instanceEnvironmentKey), newABoolLiteralExp(visible),
-                                    newABoolLiteralExp(loggingOn), newABoolLiteralExp(false), newABoolLiteralExp(false),
-                                    newAIdentifierExp(requiredIntermediateVariablesLex))), checkNullAndStop(instanceLexName));
+            List<PStm> instantiate = null;
+            try {
+                instantiate = Arrays.asList(newVariable(requiredIntermediateVariablesLex, new AUIntNumericPrimitiveType(), 0),
+                        newAAssignmentStm(newAIdentifierStateDesignator(newAIdentifier(instanceLexName)),
+                                call(fmuLexName, "instantiateCoSimulation", newAStringLiteralExp(instanceEnvironmentKey), newABoolLiteralExp(visible),
+                                        newABoolLiteralExp(loggingOn), newABoolLiteralExp(((InstanceInfo) instance.source).modelDescription.getHasEventMode()|| ((InstanceInfo) instance.source).modelDescription.getModelVariables().stream().anyMatch(v->v.getTypeIdentifier()== Fmi3TypeEnum.ClockType)), newABoolLiteralExp(true),
+                                        newAIdentifierExp(requiredIntermediateVariablesLex))), checkNullAndStop(instanceLexName));
+            } catch (XPathExpressionException e) {
+                throw new RuntimeException("Unable to process model description for "+instanceEnvironmentKey,e);
+            }
             tryBlockStatements.addAll(instantiate);
         }
 
@@ -552,12 +558,12 @@ public class MaBLTemplateGenerator {
         List<PStm> list = new ArrayList<>();
         BiFunction<String, Integer, PStm> createStatusVariable_ = (name, value) -> newALocalVariableStm(
                 newAVariableDeclaration(newLexIdentifier(name), newAIntNumericPrimitiveType(), newAExpInitializer(newAIntLiteralExp(value))));
-        list.add(createStatusVariable_.apply("FMI_STATUS_OK", 0));
-        list.add(createStatusVariable_.apply("FMI_STATUS_WARNING", 1));
-        list.add(createStatusVariable_.apply("FMI_STATUS_DISCARD", 2));
-        list.add(createStatusVariable_.apply("FMI_STATUS_ERROR", 3));
-        list.add(createStatusVariable_.apply("FMI_STATUS_FATAL", 4));
-        list.add(createStatusVariable_.apply("FMI_STATUS_PENDING", 5));
+        list.add(createStatusVariable_.apply("FMI_OK", 0));
+        list.add(createStatusVariable_.apply("FMI_WARNING", 1));
+        list.add(createStatusVariable_.apply("FMI_DISCARD", 2));
+        list.add(createStatusVariable_.apply("FMI_ERROR", 3));
+        list.add(createStatusVariable_.apply("FMI_FATAL", 4));
+        list.add(createStatusVariable_.apply("FMI_PENDING", 5));
         list.add(MableAstFactory.newALocalVariableStm(
                 MableAstFactory.newAVariableDeclaration(MableAstFactory.newAIdentifier(STATUS), MableAstFactory.newAIntNumericPrimitiveType(),
                         MableAstFactory.newAExpInitializer(MableAstFactory.newAIntLiteralExp(0)))));

--- a/maestro/src/test/java/org/intocps/maestro/FloatDeclTest.java
+++ b/maestro/src/test/java/org/intocps/maestro/FloatDeclTest.java
@@ -3,6 +3,7 @@ package org.intocps.maestro;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.intocps.maestro.ast.AVariableDeclaration;
 import org.intocps.maestro.ast.LexIdentifier;
+import org.intocps.maestro.ast.LexLocation;
 import org.intocps.maestro.ast.analysis.AnalysisException;
 import org.intocps.maestro.ast.display.PrettyPrinter;
 import org.intocps.maestro.ast.node.AExpInitializer;
@@ -56,7 +57,7 @@ public class FloatDeclTest extends BaseApiTest {
         dscope.add(stm);
 
 
-        assertModule.assertEquals(f, new VariableFmi2Api<>(stm, decl.getType().clone(), dscope,dscope, null, new AIdentifierExp(new LexIdentifier("fr", null))));
+        assertModule.assertEquals(f, new VariableFmi2Api<>(stm, decl.getType().clone(), dscope,dscope, null, new AIdentifierExp(new LexLocation("unknown",0,0),new LexIdentifier("fr", null))));
 
 
         String spec = PrettyPrinter.print(builder.build());

--- a/maestro/src/test/java/org/intocps/maestro/OnlineTestUtils.java
+++ b/maestro/src/test/java/org/intocps/maestro/OnlineTestUtils.java
@@ -2,6 +2,7 @@ package org.intocps.maestro;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.intocps.maestro.ast.LexLocation;
 import org.intocps.maestro.ast.analysis.AnalysisException;
 import org.intocps.maestro.ast.analysis.DepthFirstAnalysisAdaptor;
 import org.intocps.maestro.ast.node.ALoadExp;
@@ -92,7 +93,7 @@ public class OnlineTestUtils {
                             if (updatePath) {
                                 List<PExp> newArgs = new Vector<>();
                                 newArgs.addAll(node.getArgs());
-                                newArgs.set(2, new AStringLiteralExp("target/online-cache/" + fmuName));
+                                newArgs.set(2, new AStringLiteralExp(new LexLocation("unknown",0,0),"target/online-cache/" + fmuName));
                                 node.setArgs(newArgs);
                             }
                         } catch (MalformedURLException e) {

--- a/maestro/src/test/java/org/intocps/maestro/fmi3/BuilderFmi3Test.java
+++ b/maestro/src/test/java/org/intocps/maestro/fmi3/BuilderFmi3Test.java
@@ -483,7 +483,7 @@ public class BuilderFmi3Test {
 
 //       //step the instance
         Map.Entry<FmiBuilder.BoolVariable<PStm>, InstanceVariableFmi3Api.StepResult> stepRes = instance.step(scope, currentCommunicationPoint,
-                stepSize, new ABoolLiteralExp(false));
+                stepSize, new ABoolLiteralExp(new LexLocation("unknown",0,0),false));
 
         currentCommunicationPoint.setValue(currentCommunicationPoint.toMath().addition(stepSize));
 

--- a/maestro/src/test/java/org/intocps/maestro/fmi3/BuilderFmi3Test.java
+++ b/maestro/src/test/java/org/intocps/maestro/fmi3/BuilderFmi3Test.java
@@ -161,7 +161,7 @@ public class BuilderFmi3Test {
 
 //       //step the instance
         Map.Entry<FmiBuilder.BoolVariable<PStm>, InstanceVariableFmi3Api.StepResult> stepRes = instance.step(scope, currentCommunicationPoint,
-                stepSize, new ABoolLiteralExp(new LexLocation("unknown",0,0),false));
+                stepSize, new ABoolLiteralExp(new LexLocation("unknown",0,0),false),null);
 
         currentCommunicationPoint.setValue(currentCommunicationPoint.toMath().addition(stepSize));
         csv.log(currentCommunicationPoint);
@@ -323,7 +323,7 @@ public class BuilderFmi3Test {
         FmiBuilder.DoubleVariable<PStm> currentCommunicationPoint = scope.store("time", 0d);
         FmiBuilder.DoubleVariable<PStm> stepSize = scope.store("step", 0.1d);
         Map.Entry<FmiBuilder.BoolVariable<PStm>, InstanceVariableFmi3Api.StepResult> stepRes = instance.step(scope, currentCommunicationPoint,
-                stepSize, new ABoolLiteralExp(new LexLocation("unknown",0,0),false));
+                stepSize, new ABoolLiteralExp(new LexLocation("unknown",0,0),false),null);
 
 //        stepRes.getValue().getLastSuccessfulTime()
 
@@ -483,7 +483,7 @@ public class BuilderFmi3Test {
 
 //       //step the instance
         Map.Entry<FmiBuilder.BoolVariable<PStm>, InstanceVariableFmi3Api.StepResult> stepRes = instance.step(scope, currentCommunicationPoint,
-                stepSize, new ABoolLiteralExp(new LexLocation("unknown",0,0),false));
+                stepSize, new ABoolLiteralExp(new LexLocation("unknown",0,0),false),null);
 
         currentCommunicationPoint.setValue(currentCommunicationPoint.toMath().addition(stepSize));
 

--- a/maestro/src/test/java/org/intocps/maestro/fmi3/BuilderFmi3Test.java
+++ b/maestro/src/test/java/org/intocps/maestro/fmi3/BuilderFmi3Test.java
@@ -5,6 +5,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.intocps.fmi.jnifmuapi.fmi3.Fmu3;
 import org.intocps.maestro.Mabl;
+import org.intocps.maestro.ast.LexLocation;
 import org.intocps.maestro.ast.display.PrettyPrinter;
 import org.intocps.maestro.ast.node.*;
 import org.intocps.maestro.core.Framework;
@@ -160,7 +161,7 @@ public class BuilderFmi3Test {
 
 //       //step the instance
         Map.Entry<FmiBuilder.BoolVariable<PStm>, InstanceVariableFmi3Api.StepResult> stepRes = instance.step(scope, currentCommunicationPoint,
-                stepSize, new ABoolLiteralExp(false));
+                stepSize, new ABoolLiteralExp(new LexLocation("unknown",0,0),false));
 
         currentCommunicationPoint.setValue(currentCommunicationPoint.toMath().addition(stepSize));
         csv.log(currentCommunicationPoint);
@@ -322,7 +323,7 @@ public class BuilderFmi3Test {
         FmiBuilder.DoubleVariable<PStm> currentCommunicationPoint = scope.store("time", 0d);
         FmiBuilder.DoubleVariable<PStm> stepSize = scope.store("step", 0.1d);
         Map.Entry<FmiBuilder.BoolVariable<PStm>, InstanceVariableFmi3Api.StepResult> stepRes = instance.step(scope, currentCommunicationPoint,
-                stepSize, new ABoolLiteralExp(false));
+                stepSize, new ABoolLiteralExp(new LexLocation("unknown",0,0),false));
 
 //        stepRes.getValue().getLastSuccessfulTime()
 

--- a/maestro/src/test/resources/jacobian_step_builder/stabilization/twoMassSpringDampers.mabl
+++ b/maestro/src/test/resources/jacobian_step_builder/stabilization/twoMassSpringDampers.mabl
@@ -9,12 +9,12 @@ real START_TIME = 0.0;
 real END_TIME = 10.0;
 real STEP_SIZE = 0.001;
 
-   	int FMI_STATUS_OK = 0;
-  	int FMI_STATUS_WARNING = 1;
-  	int FMI_STATUS_DISCARD = 2;
-  	int FMI_STATUS_ERROR = 3;
-  	int FMI_STATUS_FATAL = 4;
-  	int FMI_STATUS_PENDING = 5;
+   	int FMI_OK = 0;
+  	int FMI_WARNING = 1;
+  	int FMI_DISCARD = 2;
+  	int FMI_ERROR = 3;
+  	int FMI_FATAL = 4;
+  	int FMI_PENDING = 5;
 
 
 Logger logger = load("Logger");

--- a/maestro/src/test/resources/specifications/full/initialize_singleWaterTank/foldedspec.mabl
+++ b/maestro/src/test/resources/specifications/full/initialize_singleWaterTank/foldedspec.mabl
@@ -6,12 +6,12 @@ import Initializer;
 @Framework("FMI2");
 @FrameworkConfig("FMI2","@file: env.json");
 {
-int FMI_STATUS_OK = 0;
-int FMI_STATUS_WARNING = 1;
-int FMI_STATUS_DISCARD = 2;
-int FMI_STATUS_ERROR = 3;
-int FMI_STATUS_FATAL = 4;
-int FMI_STATUS_PENDING = 5;
+int FMI_OK = 0;
+int FMI_WARNING = 1;
+int FMI_DISCARD = 2;
+int FMI_ERROR = 3;
+int FMI_FATAL = 4;
+int FMI_PENDING = 5;
 int status = 0;
 
 Math math = load("Math");

--- a/modeldefinitionchecker/pom.xml
+++ b/modeldefinitionchecker/pom.xml
@@ -17,26 +17,6 @@
     <properties>
         <overture.version>2.4.4</overture.version>
     </properties>
-
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>overture-m2-dev</id>
-            <url>
-                http://overture.au.dk/artifactory/simple/overture-development/
-            </url>
-        </pluginRepository>
-    </pluginRepositories>
-
-    <repositories>
-        <repository>
-            <id>overture-m2-dev</id>
-            <url>
-                http://overture.au.dk/artifactory/simple/overture-development/
-            </url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -170,28 +150,5 @@
             </plugins>
         </pluginManagement>
     </build>
-
-    <profiles>
-        <profile>
-            <id>github</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>env.CI</name>
-                </property>
-            </activation>
-            <repositories>
-                <repository>
-                    <id>overture-m2-dev</id>
-                    <url>
-                        http://overture.au.dk/artifactory/simple/overture-development/
-                    </url>
-                    <snapshots>
-                        <updatePolicy>interval:30</updatePolicy>
-                    </snapshots>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
 </project>
 

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,310 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Maven Start Up Batch script
+#
+# Required ENV vars:
+# ------------------
+#   JAVA_HOME - location of a JDK home dir
+#
+# Optional ENV vars
+# -----------------
+#   M2_HOME - location of maven2's installed home dir
+#   MAVEN_OPTS - parameters passed to the Java VM when running Maven
+#     e.g. to debug Maven itself, use
+#       set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+# ----------------------------------------------------------------------------
+
+if [ -z "$MAVEN_SKIP_RC" ] ; then
+
+  if [ -f /etc/mavenrc ] ; then
+    . /etc/mavenrc
+  fi
+
+  if [ -f "$HOME/.mavenrc" ] ; then
+    . "$HOME/.mavenrc"
+  fi
+
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+mingw=false
+case "`uname`" in
+  CYGWIN*) cygwin=true ;;
+  MINGW*) mingw=true;;
+  Darwin*) darwin=true
+    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
+    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+    if [ -z "$JAVA_HOME" ]; then
+      if [ -x "/usr/libexec/java_home" ]; then
+        export JAVA_HOME="`/usr/libexec/java_home`"
+      else
+        export JAVA_HOME="/Library/Java/Home"
+      fi
+    fi
+    ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=`java-config --jre-home`
+  fi
+fi
+
+if [ -z "$M2_HOME" ] ; then
+  ## resolve links - $0 may be a link to maven's home
+  PRG="$0"
+
+  # need this for relative symlinks
+  while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+      PRG="$link"
+    else
+      PRG="`dirname "$PRG"`/$link"
+    fi
+  done
+
+  saveddir=`pwd`
+
+  M2_HOME=`dirname "$PRG"`/..
+
+  # make it fully qualified
+  M2_HOME=`cd "$M2_HOME" && pwd`
+
+  cd "$saveddir"
+  # echo Using m2 at $M2_HOME
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$M2_HOME" ] &&
+    M2_HOME=`cygpath --unix "$M2_HOME"`
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For Mingw, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$M2_HOME" ] &&
+    M2_HOME="`(cd "$M2_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  javaExecutable="`which javac`"
+  if [ -n "$javaExecutable" ] && ! [ "`expr \"$javaExecutable\" : '\([^ ]*\)'`" = "no" ]; then
+    # readlink(1) is not available as standard on Solaris 10.
+    readLink=`which readlink`
+    if [ ! `expr "$readLink" : '\([^ ]*\)'` = "no" ]; then
+      if $darwin ; then
+        javaHome="`dirname \"$javaExecutable\"`"
+        javaExecutable="`cd \"$javaHome\" && pwd -P`/javac"
+      else
+        javaExecutable="`readlink -f \"$javaExecutable\"`"
+      fi
+      javaHome="`dirname \"$javaExecutable\"`"
+      javaHome=`expr "$javaHome" : '\(.*\)/bin'`
+      JAVA_HOME="$javaHome"
+      export JAVA_HOME
+    fi
+  fi
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD="`which java`"
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "  We cannot execute $JAVACMD" >&2
+  exit 1
+fi
+
+if [ -z "$JAVA_HOME" ] ; then
+  echo "Warning: JAVA_HOME environment variable is not set."
+fi
+
+CLASSWORLDS_LAUNCHER=org.codehaus.plexus.classworlds.launcher.Launcher
+
+# traverses directory structure from process work directory to filesystem root
+# first directory with .mvn subdirectory is considered project base directory
+find_maven_basedir() {
+
+  if [ -z "$1" ]
+  then
+    echo "Path not specified to find_maven_basedir"
+    return 1
+  fi
+
+  basedir="$1"
+  wdir="$1"
+  while [ "$wdir" != '/' ] ; do
+    if [ -d "$wdir"/.mvn ] ; then
+      basedir=$wdir
+      break
+    fi
+    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
+    if [ -d "${wdir}" ]; then
+      wdir=`cd "$wdir/.."; pwd`
+    fi
+    # end of workaround
+  done
+  echo "${basedir}"
+}
+
+# concatenates all lines of a file
+concat_lines() {
+  if [ -f "$1" ]; then
+    echo "$(tr -s '\n' ' ' < "$1")"
+  fi
+}
+
+BASE_DIR=`find_maven_basedir "$(pwd)"`
+if [ -z "$BASE_DIR" ]; then
+  exit 1;
+fi
+
+##########################################################################################
+# Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+# This allows using the maven wrapper in projects that prohibit checking in binary data.
+##########################################################################################
+if [ -r "$BASE_DIR/.mvn/wrapper/maven-wrapper.jar" ]; then
+    if [ "$MVNW_VERBOSE" = true ]; then
+      echo "Found .mvn/wrapper/maven-wrapper.jar"
+    fi
+else
+    if [ "$MVNW_VERBOSE" = true ]; then
+      echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
+    fi
+    if [ -n "$MVNW_REPOURL" ]; then
+      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+    else
+      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+    fi
+    while IFS="=" read key value; do
+      case "$key" in (wrapperUrl) jarUrl="$value"; break ;;
+      esac
+    done < "$BASE_DIR/.mvn/wrapper/maven-wrapper.properties"
+    if [ "$MVNW_VERBOSE" = true ]; then
+      echo "Downloading from: $jarUrl"
+    fi
+    wrapperJarPath="$BASE_DIR/.mvn/wrapper/maven-wrapper.jar"
+    if $cygwin; then
+      wrapperJarPath=`cygpath --path --windows "$wrapperJarPath"`
+    fi
+
+    if command -v wget > /dev/null; then
+        if [ "$MVNW_VERBOSE" = true ]; then
+          echo "Found wget ... using wget"
+        fi
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            wget "$jarUrl" -O "$wrapperJarPath"
+        else
+            wget --http-user=$MVNW_USERNAME --http-password=$MVNW_PASSWORD "$jarUrl" -O "$wrapperJarPath"
+        fi
+    elif command -v curl > /dev/null; then
+        if [ "$MVNW_VERBOSE" = true ]; then
+          echo "Found curl ... using curl"
+        fi
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            curl -o "$wrapperJarPath" "$jarUrl" -f
+        else
+            curl --user $MVNW_USERNAME:$MVNW_PASSWORD -o "$wrapperJarPath" "$jarUrl" -f
+        fi
+
+    else
+        if [ "$MVNW_VERBOSE" = true ]; then
+          echo "Falling back to using Java to download"
+        fi
+        javaClass="$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.java"
+        # For Cygwin, switch paths to Windows format before running javac
+        if $cygwin; then
+          javaClass=`cygpath --path --windows "$javaClass"`
+        fi
+        if [ -e "$javaClass" ]; then
+            if [ ! -e "$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.class" ]; then
+                if [ "$MVNW_VERBOSE" = true ]; then
+                  echo " - Compiling MavenWrapperDownloader.java ..."
+                fi
+                # Compiling the Java class
+                ("$JAVA_HOME/bin/javac" "$javaClass")
+            fi
+            if [ -e "$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.class" ]; then
+                # Running the downloader
+                if [ "$MVNW_VERBOSE" = true ]; then
+                  echo " - Running MavenWrapperDownloader.java ..."
+                fi
+                ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$MAVEN_PROJECTBASEDIR")
+            fi
+        fi
+    fi
+fi
+##########################################################################################
+# End of extension
+##########################################################################################
+
+export MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}
+if [ "$MVNW_VERBOSE" = true ]; then
+  echo $MAVEN_PROJECTBASEDIR
+fi
+MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$M2_HOME" ] &&
+    M2_HOME=`cygpath --path --windows "$M2_HOME"`
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
+    MAVEN_PROJECTBASEDIR=`cygpath --path --windows "$MAVEN_PROJECTBASEDIR"`
+fi
+
+# Provide a "standardized" way to retrieve the CLI args that will
+# work with both Windows and non-Windows executions.
+MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $@"
+export MAVEN_CMD_LINE_ARGS
+
+WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+exec "$JAVACMD" \
+  $MAVEN_OPTS \
+  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+  "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,182 @@
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Maven Start Up Batch script
+@REM
+@REM Required ENV vars:
+@REM JAVA_HOME - location of a JDK home dir
+@REM
+@REM Optional ENV vars
+@REM M2_HOME - location of maven2's installed home dir
+@REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a keystroke before ending
+@REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
+@REM     e.g. to debug Maven itself, use
+@REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+@REM MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+@REM ----------------------------------------------------------------------------
+
+@REM Begin all REM lines with '@' in case MAVEN_BATCH_ECHO is 'on'
+@echo off
+@REM set title of command window
+title %0
+@REM enable echoing by setting MAVEN_BATCH_ECHO to 'on'
+@if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
+
+@REM set %HOME% to equivalent of $HOME
+if "%HOME%" == "" (set "HOME=%HOMEDRIVE%%HOMEPATH%")
+
+@REM Execute a user defined script before this one
+if not "%MAVEN_SKIP_RC%" == "" goto skipRcPre
+@REM check for pre script, once with legacy .bat ending and once with .cmd ending
+if exist "%HOME%\mavenrc_pre.bat" call "%HOME%\mavenrc_pre.bat"
+if exist "%HOME%\mavenrc_pre.cmd" call "%HOME%\mavenrc_pre.cmd"
+:skipRcPre
+
+@setlocal
+
+set ERROR_CODE=0
+
+@REM To isolate internal variables from possible post scripts, we use another setlocal
+@setlocal
+
+@REM ==== START VALIDATION ====
+if not "%JAVA_HOME%" == "" goto OkJHome
+
+echo.
+echo Error: JAVA_HOME not found in your environment. >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+:OkJHome
+if exist "%JAVA_HOME%\bin\java.exe" goto init
+
+echo.
+echo Error: JAVA_HOME is set to an invalid directory. >&2
+echo JAVA_HOME = "%JAVA_HOME%" >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+@REM ==== END VALIDATION ====
+
+:init
+
+@REM Find the project base dir, i.e. the directory that contains the folder ".mvn".
+@REM Fallback to current working directory if not found.
+
+set MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%
+IF NOT "%MAVEN_PROJECTBASEDIR%"=="" goto endDetectBaseDir
+
+set EXEC_DIR=%CD%
+set WDIR=%EXEC_DIR%
+:findBaseDir
+IF EXIST "%WDIR%"\.mvn goto baseDirFound
+cd ..
+IF "%WDIR%"=="%CD%" goto baseDirNotFound
+set WDIR=%CD%
+goto findBaseDir
+
+:baseDirFound
+set MAVEN_PROJECTBASEDIR=%WDIR%
+cd "%EXEC_DIR%"
+goto endDetectBaseDir
+
+:baseDirNotFound
+set MAVEN_PROJECTBASEDIR=%EXEC_DIR%
+cd "%EXEC_DIR%"
+
+:endDetectBaseDir
+
+IF NOT EXIST "%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config" goto endReadAdditionalConfig
+
+@setlocal EnableExtensions EnableDelayedExpansion
+for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do set JVM_CONFIG_MAVEN_PROPS=!JVM_CONFIG_MAVEN_PROPS! %%a
+@endlocal & set JVM_CONFIG_MAVEN_PROPS=%JVM_CONFIG_MAVEN_PROPS%
+
+:endReadAdditionalConfig
+
+SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
+set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
+set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+
+FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
+)
+
+@REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+@REM This allows using the maven wrapper in projects that prohibit checking in binary data.
+if exist %WRAPPER_JAR% (
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Found %WRAPPER_JAR%
+    )
+) else (
+    if not "%MVNW_REPOURL%" == "" (
+        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+    )
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Couldn't find %WRAPPER_JAR%, downloading it ...
+        echo Downloading from: %DOWNLOAD_URL%
+    )
+
+    powershell -Command "&{"^
+		"$webclient = new-object System.Net.WebClient;"^
+		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+		"}"^
+		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"^
+		"}"
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Finished downloading %WRAPPER_JAR%
+    )
+)
+@REM End of extension
+
+@REM Provide a "standardized" way to retrieve the CLI args that will
+@REM work with both Windows and non-Windows executions.
+set MAVEN_CMD_LINE_ARGS=%*
+
+%MAVEN_JAVA_EXE% %JVM_CONFIG_MAVEN_PROPS% %MAVEN_OPTS% %MAVEN_DEBUG_OPTS% -classpath %WRAPPER_JAR% "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
+if ERRORLEVEL 1 goto error
+goto end
+
+:error
+set ERROR_CODE=1
+
+:end
+@endlocal & set ERROR_CODE=%ERROR_CODE%
+
+if not "%MAVEN_SKIP_RC%" == "" goto skipRcPost
+@REM check for post script, once with legacy .bat ending and once with .cmd ending
+if exist "%HOME%\mavenrc_post.bat" call "%HOME%\mavenrc_post.bat"
+if exist "%HOME%\mavenrc_post.cmd" call "%HOME%\mavenrc_post.cmd"
+:skipRcPost
+
+@REM pause the script if MAVEN_BATCH_PAUSE is set to 'on'
+if "%MAVEN_BATCH_PAUSE%" == "on" pause
+
+if "%MAVEN_TERMINATE_CMD%" == "on" exit %ERROR_CODE%
+
+exit /B %ERROR_CODE%

--- a/parser/src/main/antlr4/org/intocps/maestro/parser/MablLexer.g4
+++ b/parser/src/main/antlr4/org/intocps/maestro/parser/MablLexer.g4
@@ -106,6 +106,7 @@ AT_FRAMEWORK:      '@Framework';
 AT_FRAMEWORK_CONFIG:'@FrameworkConfig';
 AT_TRANSFER:        '@Transfer';
 AT_TRANSFER_AS:        '@TransferAs';
+AT_DEBUG:            '@Debug';
 
 // Whitespace and comments
 WS:                 [ \t\r\n\u000C]+ -> channel(HIDDEN);

--- a/parser/src/main/antlr4/org/intocps/maestro/parser/MablParser.g4
+++ b/parser/src/main/antlr4/org/intocps/maestro/parser/MablParser.g4
@@ -65,6 +65,8 @@ statement
                      name=STRING_LITERAL RPAREN ';'             #instanceMapping
     | AT_TRANSFER (LPAREN (names+=STRING_LITERAL
                     (',' names+=STRING_LITERAL)*)*  RPAREN)* ';'  #transfer
+    | AT_DEBUG (LPAREN (names+=STRING_LITERAL
+                        (',' names+=STRING_LITERAL)*)*  RPAREN)* ';'  #debug
     | AT_TRANSFER_AS (LPAREN (names+=STRING_LITERAL
                         (',' names+=STRING_LITERAL)*)*  RPAREN)* ';'  #transferAs
     | AT_CONFIG LPAREN  config=STRING_LITERAL  RPAREN ';'       #config

--- a/parser/src/main/java/org/intocps/maestro/parser/MablParserUtil.java
+++ b/parser/src/main/java/org/intocps/maestro/parser/MablParserUtil.java
@@ -1,6 +1,7 @@
 package org.intocps.maestro.parser;
 
 import org.antlr.v4.runtime.*;
+import org.intocps.maestro.ast.LexLocation;
 import org.intocps.maestro.ast.LexToken;
 import org.intocps.maestro.ast.node.ARootDocument;
 import org.intocps.maestro.core.messages.IErrorReporter;
@@ -17,6 +18,11 @@ import java.util.Vector;
 public class MablParserUtil {
     final static Logger logger = LoggerFactory.getLogger(MablParserUtil.class);
 
+    public static LexLocation getLexLocation(ParserRuleContext context) {
+        var token = context.start;
+        return new LexLocation(token.getTokenSource().getSourceName(), token.getLine(), token.getCharPositionInLine());
+    }
+
     private static List<ARootDocument> parseStreams(List<CharStream> specStreams) {
         List<ARootDocument> documentList = new Vector<>();
         for (CharStream specStream : specStreams) {
@@ -31,7 +37,7 @@ public class MablParserUtil {
         p.addErrorListener(new BaseErrorListener() {
             @Override
             public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg,
-                    RecognitionException e) {
+                                    RecognitionException e) {
                 System.out.println(specStreams);
                 throw new IllegalStateException("failed to parse at line " + line + " due to " + msg, e);
             }
@@ -48,7 +54,7 @@ public class MablParserUtil {
         p.addErrorListener(new BaseErrorListener() {
             @Override
             public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg,
-                    RecognitionException e) {
+                                    RecognitionException e) {
                 //throw new IllegalStateException("failed to parse at line " + line + " due to " + msg, e);
                 reporter.report(0, msg, new LexToken("", line, 0));
             }

--- a/parser/src/main/java/org/intocps/maestro/parser/ParseTree2AstConverter.java
+++ b/parser/src/main/java/org/intocps/maestro/parser/ParseTree2AstConverter.java
@@ -13,6 +13,8 @@ import java.util.Objects;
 import java.util.Vector;
 import java.util.stream.Collectors;
 
+import static org.intocps.maestro.parser.MablParserUtil.getLexLocation;
+
 public class ParseTree2AstConverter extends MablParserBaseVisitor<INode> {
     final static Logger logger = LoggerFactory.getLogger(ParseTree2AstConverter.class);
 
@@ -135,12 +137,13 @@ public class ParseTree2AstConverter extends MablParserBaseVisitor<INode> {
     }
 
 
+
     @Override
     public INode visitTransfer(MablParser.TransferContext ctx) {
         ATransferStm stm = new ATransferStm();
 
         if (ctx.names != null && !ctx.names.isEmpty()) {
-            stm.setNames(ctx.names.stream().map(Token::getText).map(s -> new AStringLiteralExp(s.substring(1, s.length() - 1)))
+            stm.setNames(ctx.names.stream().map(Token::getText).map(s -> new AStringLiteralExp(getLexLocation(ctx),s.substring(1, s.length() - 1)))
                     .collect(Collectors.toList()));
         }
 
@@ -152,7 +155,7 @@ public class ParseTree2AstConverter extends MablParserBaseVisitor<INode> {
         ATransferAsStm stm = new ATransferAsStm();
 
         if (ctx.names != null && !ctx.names.isEmpty()) {
-            stm.setNames(ctx.names.stream().map(Token::getText).map(s -> new AStringLiteralExp(s.substring(1, s.length() - 1)))
+            stm.setNames(ctx.names.stream().map(Token::getText).map(s -> new AStringLiteralExp(getLexLocation(ctx),s.substring(1, s.length() - 1)))
                     .collect(Collectors.toList()));
         }
 
@@ -279,13 +282,16 @@ public class ParseTree2AstConverter extends MablParserBaseVisitor<INode> {
 
         exp.setLeft((PExp) this.visit(ctx.left));
         exp.setRight((PExp) this.visit(ctx.right));
+        exp.setLocation(getLexLocation(ctx));
 
         return exp;
     }
 
     @Override
     public INode visitParenExp(MablParser.ParenExpContext ctx) {
-        return new AParExp((PExp) this.visit(ctx.expression()));
+        var exp= new AParExp(getLexLocation(ctx),(PExp) this.visit(ctx.expression()));
+        exp.setLocation(getLexLocation(ctx));
+        return exp;
     }
 
     @Override
@@ -303,11 +309,13 @@ public class ParseTree2AstConverter extends MablParserBaseVisitor<INode> {
             AFieldExp fieldExp = new AFieldExp();
             fieldExp.setRoot(root);
             fieldExp.setField(convert(ctx.IDENTIFIER()));
+            fieldExp.setLocation(getLexLocation(ctx));
             return fieldExp;
         } else if (ctx.methodCall() != null) {
             //object call
             ACallExp call = (ACallExp) this.visit(ctx.methodCall());
             call.setObject(root);
+            call.setLocation(getLexLocation(ctx));
             return call;
         }
 
@@ -331,13 +339,13 @@ public class ParseTree2AstConverter extends MablParserBaseVisitor<INode> {
             exp = new AMinusUnaryExp();
         }
         exp.setExp((PExp) this.visit(ctx.expression()));
-
+        exp.setLocation(getLexLocation(ctx));
         return exp;
     }
 
     @Override
     public INode visitIdentifierExp(MablParser.IdentifierExpContext ctx) {
-        return new AIdentifierExp(convert(ctx.IDENTIFIER()));
+        return new AIdentifierExp(getLexLocation(ctx),convert(ctx.IDENTIFIER()));
     }
 
     @Override
@@ -350,6 +358,7 @@ public class ParseTree2AstConverter extends MablParserBaseVisitor<INode> {
         if (ctx.index != null) {
             apply.setIndices(ctx.index.stream().map(e -> (PExp) this.visit(e)).collect(Collectors.toList()));
         }
+        apply.setLocation(getLexLocation(ctx));
         return apply;
     }
 
@@ -360,7 +369,7 @@ public class ParseTree2AstConverter extends MablParserBaseVisitor<INode> {
 
     @Override
     public INode visitParExpression(MablParser.ParExpressionContext ctx) {
-        return new AParExp((PExp) this.visit(ctx.expression()));
+        return new AParExp(getLexLocation(ctx),(PExp) this.visit(ctx.expression()));
     }
 
     void checkList(List source, List processed) {
@@ -383,6 +392,7 @@ public class ParseTree2AstConverter extends MablParserBaseVisitor<INode> {
     public INode visitMethodCall(MablParser.MethodCallContext ctx) {
 
         ACallExp call = new ACallExp();
+        call.setLocation(getLexLocation(ctx));
 
         if (ctx.expressionList() != null && ctx.expressionList().expression() != null) {
             List<PExp> args = ctx.expressionList().expression().stream().map(this::visit).map(PExp.class::cast).collect(Collectors.toList());
@@ -398,10 +408,12 @@ public class ParseTree2AstConverter extends MablParserBaseVisitor<INode> {
 
         if (call.getMethodName().getText().equals("load")) {
             ALoadExp load = new ALoadExp();
+            load.setLocation(getLexLocation(ctx));
             load.setArgs(call.getArgs());
             return load;
         } else if (call.getMethodName().getText().equals("unload")) {
             AUnloadExp unload = new AUnloadExp();
+            unload.setLocation(getLexLocation(ctx));
             unload.setArgs(call.getArgs());
             return unload;
         }
@@ -498,24 +510,29 @@ public class ParseTree2AstConverter extends MablParserBaseVisitor<INode> {
     public INode visitLiteral(MablParser.LiteralContext ctx) {
         if (ctx.BOOL_LITERAL() != null) {
             ABoolLiteralExp literal = new ABoolLiteralExp();
+            literal.setLocation(getLexLocation(ctx));
             literal.setValue(Boolean.parseBoolean(ctx.BOOL_LITERAL().getText()));
             return literal;
         } else if (ctx.DECIMAL_LITERAL() != null) {
             AIntLiteralExp literal = new AIntLiteralExp();
+            literal.setLocation(getLexLocation(ctx));
             literal.setValue(Integer.parseInt(ctx.DECIMAL_LITERAL().getText()));
             return literal;
         } else if (ctx.FLOAT_LITERAL() != null) {
             ARealLiteralExp literal = new ARealLiteralExp();
+            literal.setLocation(getLexLocation(ctx));
             literal.setValue(Double.parseDouble(ctx.FLOAT_LITERAL().getText()));
             return literal;
 
         } else if (ctx.STRING_LITERAL() != null) {
             AStringLiteralExp literal = new AStringLiteralExp();
+            literal.setLocation(getLexLocation(ctx));
             //remove quotes
             literal.setValue((ctx.STRING_LITERAL().getText().substring(1, ctx.STRING_LITERAL().getText().length() - 1)));
             return literal;
         } else if (ctx.NULL_LITERAL() != null) {
             ANullExp literal = new ANullExp();
+            literal.setLocation(getLexLocation(ctx));
             //remove quotes
             literal.setToken(convertToLexToken(ctx.NULL_LITERAL().getSymbol()));
             return literal;
@@ -621,6 +638,7 @@ public class ParseTree2AstConverter extends MablParserBaseVisitor<INode> {
     public INode visitRefExpression(MablParser.RefExpressionContext ctx) {
         ARefExp exp = new ARefExp();
         exp.setExp((PExp) this.visit(ctx.expression()));
+        exp.setLocation(getLexLocation(ctx));
         return exp;
     }
 

--- a/parser/src/main/java/org/intocps/maestro/parser/ParseTree2AstConverter.java
+++ b/parser/src/main/java/org/intocps/maestro/parser/ParseTree2AstConverter.java
@@ -136,7 +136,17 @@ public class ParseTree2AstConverter extends MablParserBaseVisitor<INode> {
 
     }
 
+    @Override
+    public INode visitDebug(MablParser.DebugContext ctx) {
+        ADebugStm stm = new ADebugStm();
 
+        if (ctx.names != null && !ctx.names.isEmpty()) {
+            stm.setTokens(ctx.names.stream().map(Token::getText).map(s -> new AStringLiteralExp(getLexLocation(ctx),s.substring(1, s.length() - 1)))
+                    .collect(Collectors.toList()));
+        }
+
+        return stm;
+    }
 
     @Override
     public INode visitTransfer(MablParser.TransferContext ctx) {

--- a/parser/src/main/java/org/intocps/maestro/parser/template/MablSwapConditionParserUtil.java
+++ b/parser/src/main/java/org/intocps/maestro/parser/template/MablSwapConditionParserUtil.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
+import static org.intocps.maestro.parser.MablParserUtil.getLexLocation;
 public class MablSwapConditionParserUtil {
 
     public static PExp parse(CharStream specStreams) {
@@ -92,7 +92,7 @@ public class MablSwapConditionParserUtil {
 
         @Override
         public INode visitParenExp(MablSwapConditionParser.ParenExpContext ctx) {
-            return new AParExp((PExp) this.visit(ctx.expression()));
+            return new AParExp(getLexLocation(ctx),(PExp) this.visit(ctx.expression()));
         }
 
         @Override
@@ -144,7 +144,7 @@ public class MablSwapConditionParserUtil {
 
         @Override
         public INode visitIdentifierExp(MablSwapConditionParser.IdentifierExpContext ctx) {
-            return new AIdentifierExp(convert(ctx.IDENTIFIER()));
+            return new AIdentifierExp(getLexLocation(ctx),convert(ctx.IDENTIFIER()));
         }
 
         @Override
@@ -163,7 +163,7 @@ public class MablSwapConditionParserUtil {
 
         @Override
         public INode visitParExpression(MablSwapConditionParser.ParExpressionContext ctx) {
-            return new AParExp((PExp) this.visit(ctx.expression()));
+            return new AParExp(getLexLocation(ctx),(PExp) this.visit(ctx.expression()));
         }
 
         void checkList(List source, List processed) {

--- a/plugins/demo/src/main/java/org/intocps/maestro/plugin/SomePlugin.java
+++ b/plugins/demo/src/main/java/org/intocps/maestro/plugin/SomePlugin.java
@@ -41,7 +41,7 @@ public class SomePlugin extends BasicMaestroExpansionPlugin {
 
         if (config instanceof DemoConfig) {
             return Collections.singletonList(new AWhileStm(
-                    new ALessBinaryExp(new AIntLiteralExp(((DemoConfig) config).repeats), new AIntLiteralExp(((DemoConfig) config).repeats)),
+                    new ALessBinaryExp(new LexLocation("",0,0),new AIntLiteralExp(new LexLocation("",0,0),((DemoConfig) config).repeats), new AIntLiteralExp(new LexLocation("",0,0),((DemoConfig) config).repeats)),
                     new ABasicBlockStm()));
         }
         throw new ExpandException("Bad config type");

--- a/plugins/fixedstep/src/main/java/org/intocps/maestro/plugin/JacobianFixedStep.java
+++ b/plugins/fixedstep/src/main/java/org/intocps/maestro/plugin/JacobianFixedStep.java
@@ -1,6 +1,7 @@
 package org.intocps.maestro.plugin;
 
 import org.intocps.maestro.ast.LexIdentifier;
+import org.intocps.maestro.ast.LexLocation;
 import org.intocps.maestro.ast.node.*;
 import org.intocps.maestro.core.messages.IErrorReporter;
 import org.intocps.maestro.framework.fmi2.Fmi2SimulationEnvironment;
@@ -88,7 +89,7 @@ public class JacobianFixedStep {
         Consumer<List<PStm>> terminate = list -> {
             list.addAll(componentNames.stream().map(comp -> newExpressionStm(
                             newACallExp(newAIdentifierExp((LexIdentifier) comp.clone()), newAIdentifier("terminate"), Collections.emptyList())))
-                    .collect(Collectors.toList()));
+                    .toList());
         };
 
 
@@ -192,7 +193,7 @@ public class JacobianFixedStep {
                                                                                                     newAArrayIndexExp(newAIdentifierExp(fixedStepStatus),
                                                                                                             Arrays.asList(newAIdentifierExp(
                                                                                                                     (LexIdentifier) compIndexVar.clone())))))),
-                                                                            new AErrorStm(new AStringLiteralExp("do step failed"))), null)),
+                                                                            new AErrorStm(new AStringLiteralExp(new LexLocation("",0,0),"do step failed"))), null)),
                                                     newIf(newEqual(newAArrayIndexExp(newAIdentifierExp(fixedStepStatus),
                                                                     Arrays.asList(newAIdentifierExp((LexIdentifier) compIndexVar.clone()))),
                                                             newAIntLiteralExp(FMI_DISCARD)), newABlockStm(newExpressionStm(
@@ -219,50 +220,42 @@ public class JacobianFixedStep {
                     newIf(newNot(newAIdentifierExp(newAIdentifier(IMaestroPlugin.GLOBAL_EXECUTION_CONTINUE))),
                             !stateHandler.supportsGetSetState ? new AErrorStm() : newIf(newAIdentifierExp("discardObserved"),
 
-                                    new Supplier<PStm>() {
-                                        @Override
-                                        public PStm get() {
-                                            List<PStm> list = new Vector<>();
-                                            list.add(loopComponents(beforeList -> {
-                                                beforeList.add(newAAssignmentStm(newAIdentifierStateDesignator(newAIdentifier(fix_recoveryStepSize)),
-                                                        newAIdentifierExp(newAIdentifier(fix_stepSize))));
+                                    ((Supplier<PStm>) () -> {
+                                        List<PStm> list1 = new Vector<>();
+                                        list1.add(loopComponents(beforeList -> {
+                                            beforeList.add(newAAssignmentStm(newAIdentifierStateDesignator(newAIdentifier(fix_recoveryStepSize)),
+                                                    newAIdentifierExp(newAIdentifier(fix_stepSize))));
 
-                                                beforeList.add(newVariable("fix_recover_real_status", newARealNumericPrimitiveType(),
-                                                        newARealLiteralExp(0d)));
+                                            beforeList.add(newVariable("fix_recover_real_status", newARealNumericPrimitiveType(),
+                                                    newARealLiteralExp(0d)));
 
-                                            }, newAIdentifierExp(fixedStepStatus), newAIntLiteralExp(componentNames.size()), (index, comp) -> {
+                                        }, newAIdentifierExp(fixedStepStatus), newAIntLiteralExp(componentNames.size()), (index, comp) -> Arrays.asList(newIf(newEqual(
+                                                newAArrayIndexExp(newAIdentifierExp(fixedStepStatus), Arrays.asList(index.clone())),
+                                                newAIntLiteralExp(FMI_DISCARD)), newABlockStm(Arrays.asList(
 
-                                                return Arrays.asList(newIf(newEqual(
-                                                        newAArrayIndexExp(newAIdentifierExp(fixedStepStatus), Arrays.asList(index.clone())),
-                                                        newAIntLiteralExp(FMI_DISCARD)), newABlockStm(Arrays.asList(
+                                                newAAssignmentStm(newAIdentifierStateDesignator(newAIdentifier(fix_recovering)),
+                                                        newABoolLiteralExp(true)),
 
-                                                        newAAssignmentStm(newAIdentifierStateDesignator(newAIdentifier(fix_recovering)),
-                                                                newABoolLiteralExp(true)),
+                                                newAAssignmentStm(newAArayStateDesignator(
+                                                                newAIdentifierStateDesignator(newAIdentifier(fixedStepStatus)), index.clone()),
+                                                        call(arrayGet(componentsIdentifier, index.clone()), "getRealStatus",
+                                                                newAIntLiteralExp(FMI_STATUS_LAST_SUCCESSFUL),
+                                                                newARefExp(newAIdentifierExp("fix_recover_real_status")))),
+                                                newAAssignmentStm(newAIdentifierStateDesignator(newAIdentifier(fix_recoveryStepSize)),
+                                                        call("math", "min", newAIdentifierExp(fix_recoveryStepSize),
+                                                                newMinusExp(newAIdentifierExp("fix_recover_real_status"),
+                                                                        newAIdentifierExp("time")))), newExpressionStm(
+                                                        simLog(LogUtil.SimLogLevel.DEBUG, "Recovery time set to: %f",
+                                                                newAIdentifierExp(fix_recoveryStepSize)))
 
-                                                        newAAssignmentStm(newAArayStateDesignator(
-                                                                        newAIdentifierStateDesignator(newAIdentifier(fixedStepStatus)), index.clone()),
-                                                                call(arrayGet(componentsIdentifier, index.clone()), "getRealStatus",
-                                                                        newAIntLiteralExp(FMI_STATUS_LAST_SUCCESSFUL),
-                                                                        newARefExp(newAIdentifierExp("fix_recover_real_status")))),
-                                                        newAAssignmentStm(newAIdentifierStateDesignator(newAIdentifier(fix_recoveryStepSize)),
-                                                                call("math", "min", newAIdentifierExp(fix_recoveryStepSize),
-                                                                        newMinusExp(newAIdentifierExp("fix_recover_real_status"),
-                                                                                newAIdentifierExp("time")))), newExpressionStm(
-                                                                simLog(LogUtil.SimLogLevel.DEBUG, "Recovery time set to: %f",
-                                                                        newAIdentifierExp(fix_recoveryStepSize)))
-
-                                                )), null), newExpressionStm(call(arrayGet(componentsIdentifier, index.clone()), "setState",
-                                                        arrayGet(stateHandler.fix_comp_states, index.clone()))));
-
-
-                                            }));
-                                            list.addAll(stateHandler.freeAllStates());
-                                            list.add(newAAssignmentStm(
-                                                    newAIdentifierStateDesignator(newAIdentifier(IMaestroPlugin.GLOBAL_EXECUTION_CONTINUE)),
-                                                    newABoolLiteralExp(true)));
-                                            return newABlockStm(list);
-                                        }
-                                    }.get()
+                                        )), null), newExpressionStm(call(arrayGet(componentsIdentifier, index.clone()), "setState",
+                                                arrayGet(stateHandler.fix_comp_states, index.clone()))))));
+                                        list1.addAll(stateHandler.freeAllStates());
+                                        list1.add(newAAssignmentStm(
+                                                newAIdentifierStateDesignator(newAIdentifier(IMaestroPlugin.GLOBAL_EXECUTION_CONTINUE)),
+                                                newABoolLiteralExp(true)));
+                                        return newABlockStm(list1);
+                                    }).get()
 
 
                                     , null), null), null)), null));
@@ -337,7 +330,7 @@ public class JacobianFixedStep {
         statements.addAll(dataWriter.write());
         //loop
         statements.add(newWhile(newAnd(newAIdentifierExp(IMaestroPlugin.GLOBAL_EXECUTION_CONTINUE),
-                (newALessEqualBinaryExp(newAIdentifierExp(time), newAIdentifierExp(end)))), newABlockStm(loopStmts)));
+                newALessEqualBinaryExp(newAIdentifierExp(time), newAIdentifierExp(end))), newABlockStm(loopStmts)));
         //post simulation
         terminate.accept(statements);
         statements.addAll(dataWriter.deallocate());

--- a/plugins/fixedstep/src/main/java/org/intocps/maestro/plugin/StateHandler.java
+++ b/plugins/fixedstep/src/main/java/org/intocps/maestro/plugin/StateHandler.java
@@ -1,6 +1,7 @@
 package org.intocps.maestro.plugin;
 
 import org.intocps.maestro.ast.LexIdentifier;
+import org.intocps.maestro.ast.LexLocation;
 import org.intocps.maestro.ast.MableAstFactory;
 import org.intocps.maestro.ast.node.ARefExp;
 import org.intocps.maestro.ast.node.PExp;
@@ -92,7 +93,7 @@ public class StateHandler {
         //free states
         Consumer<List<PStm>> freeAllStates = (list) -> componentNames.forEach(comp -> {
             list.add(newAAssignmentStm(getCompStatusDesignator.apply(comp),
-                    call(newAIdentifierExp((LexIdentifier) comp.clone()), "freeState", new ARefExp(getCompStateDesignator.apply(comp)))));
+                    call(newAIdentifierExp((LexIdentifier) comp.clone()), "freeState", new ARefExp(new LexLocation("",0,0),getCompStateDesignator.apply(comp)))));
             checkStatus.accept(Map.entry(true, "free state failed"), Map.entry(comp, list));
         });
 

--- a/plugins/initializer/src/main/java/org/intocps/maestro/plugin/initializer/PhasePredicates3.java
+++ b/plugins/initializer/src/main/java/org/intocps/maestro/plugin/initializer/PhasePredicates3.java
@@ -3,6 +3,7 @@ package org.intocps.maestro.plugin.initializer;
 
 import org.intocps.maestro.fmi.ModelDescription;
 import org.intocps.maestro.fmi.fmi3.Fmi3Causality;
+import org.intocps.maestro.fmi.fmi3.Fmi3TypeEnum;
 import org.intocps.maestro.fmi.fmi3.Fmi3Variable;
 
 import java.util.function.Predicate;
@@ -10,14 +11,15 @@ import java.util.function.Predicate;
 public class PhasePredicates3 {
 
     public static Predicate<Fmi3Variable> iniPhase() {
-        return o -> ((o.getInitial() == ModelDescription.Initial.Exact || o.getInitial() == ModelDescription.Initial.Approx) &&
+        return o ->o.getTypeIdentifier()!= Fmi3TypeEnum.ClockType && ((o.getInitial() == ModelDescription.Initial.Exact || o.getInitial() == ModelDescription.Initial.Approx) &&
                 o.getVariability() != ModelDescription.Variability.Constant) ||
-                (o.getCausality() == Fmi3Causality.Parameter && o.getVariability() == ModelDescription.Variability.Tunable);
+                (o.getCausality() == Fmi3Causality.Parameter && o.getVariability() != ModelDescription.Variability.Tunable);
     }
 
 
     public static Predicate<Fmi3Variable> inPhase() {
-        return o -> (o.getCausality() == Fmi3Causality.Input && o.getInitial() == ModelDescription.Initial.Calculated ||
-                o.getCausality() == Fmi3Causality.Parameter && o.getVariability() == ModelDescription.Variability.Tunable);
+        return o ->o.getTypeIdentifier()!= Fmi3TypeEnum.ClockType &&
+                (o.getCausality() == Fmi3Causality.Input && o.getInitial() == ModelDescription.Initial.Calculated ||
+                o.getCausality() == Fmi3Causality.Parameter && o.getVariability() != ModelDescription.Variability.Tunable);
     }
 }

--- a/plugins/initializer/src/main/kotlin/Initializer.kt
+++ b/plugins/initializer/src/main/kotlin/Initializer.kt
@@ -18,8 +18,10 @@ import org.intocps.maestro.framework.fmi2.InvalidVariableStringException
 import org.intocps.maestro.framework.fmi2.ModelConnection
 import org.intocps.maestro.framework.fmi2.api.FmiBuilder
 import org.intocps.maestro.framework.fmi2.api.FmiBuilder.ArrayVariable
+import org.intocps.maestro.framework.fmi2.api.FmiBuilder.ExpressionValue
 import org.intocps.maestro.framework.fmi2.api.FmiBuilder.SimulationInstance
 import org.intocps.maestro.framework.fmi2.api.mabl.*
+import org.intocps.maestro.framework.fmi2.api.mabl.PortFmi3Api.PortFilters.isClock
 import org.intocps.maestro.framework.fmi2.api.mabl.scoping.DynamicActiveBuilderScope
 import org.intocps.maestro.framework.fmi2.api.mabl.scoping.ScopeFmi2Api
 import org.intocps.maestro.framework.fmi2.api.mabl.values.BooleanExpressionValue
@@ -290,16 +292,20 @@ class Initializer : BasicMaestroExpansionPlugin {
 
     private fun toCompMap(map: List<ComponentVariableFmi2Api>?): Map<String, ComponentVariableFmi2Api> {
         return if (map == null) emptyMap() else map.stream()
-            .collect(Collectors.toMap({ v: ComponentVariableFmi2Api -> v.name },
-                Function.identity(),
-                { u: ComponentVariableFmi2Api?, v: ComponentVariableFmi2Api? -> u }) { LinkedHashMap() })
+            .collect(
+                Collectors.toMap(
+                    { v: ComponentVariableFmi2Api -> v.name },
+                    Function.identity(),
+                    { u: ComponentVariableFmi2Api?, v: ComponentVariableFmi2Api? -> u }) { LinkedHashMap() })
     }
 
     private fun toInstanceMap(map: List<InstanceVariableFmi3Api>?): Map<String, InstanceVariableFmi3Api> {
         return if (map == null) emptyMap() else map.stream()
-            .collect(Collectors.toMap({ v: InstanceVariableFmi3Api -> v.name },
-                Function.identity(),
-                { u: InstanceVariableFmi3Api?, v: InstanceVariableFmi3Api? -> u }) { LinkedHashMap() })
+            .collect(
+                Collectors.toMap(
+                    { v: InstanceVariableFmi3Api -> v.name },
+                    Function.identity(),
+                    { u: InstanceVariableFmi3Api?, v: InstanceVariableFmi3Api? -> u }) { LinkedHashMap() })
     }
 
     override fun <R : Any?> expandWithRuntimeAddition(
@@ -445,7 +451,7 @@ class Initializer : BasicMaestroExpansionPlugin {
 
 
         //TODO not sure what this is - stabilization maybe
-        val instructions = instantiationOrder.map { i ->
+        val instructions = instantiationOrder.map { s -> s.filter { p -> !isClockPort(p) } }.map { i ->
             createInitInstructions(
                 i.toList(), dynamicScope, fmuInstances, fmu3Instances, booleanLogic, math
             )
@@ -472,6 +478,59 @@ class Initializer : BasicMaestroExpansionPlugin {
         setRemainingInputs(fmuInstances, builder)
         setRemainingInputs3(fmu3Instances, builder)
 
+        //clocks
+        /* input clocks we need context info from the md description of these
+        *  periodic-constant:
+        *   get interval
+        *   get shift
+        *  periodic- fixed/turnable:
+        *   if md intervalDecimal -> set interval
+        *   if not intervalDecimal ->
+        *     get interval
+        *     get shift
+        *  aperiodic- changning/countdown
+        *    get interval
+        * */
+
+//set intervalDecimal if needed
+        fmu3Instances.values.forEach(Consumer { instance: InstanceVariableFmi3Api ->
+            instance.ports.filter { p -> isClock.test(p) }.filter { p ->
+                val variable = p.scalarVariable.variable;
+                variable.causality == Fmi3Causality.Input && variable is ClockVariable && (variable.interval == Fmi3ClockInterval.Fixed || variable.interval == Fmi3ClockInterval.Tunable) && variable.intervalDecimal != null
+            }.stream().forEach { port: PortFmi3Api ->
+                instance.set(
+                    port,
+                    DoubleExpressionValue.of((port.scalarVariable.variable as ClockVariable).intervalDecimal!!)
+                )
+            }
+        })
+
+        // get interval and shift
+
+        fmu3Instances.values.forEach(Consumer { instance: InstanceVariableFmi3Api ->
+            instance.ports.filter { p -> isClock.test(p) }.filter { p ->
+                val variable = p.scalarVariable.variable
+                variable.causality == Fmi3Causality.Input && variable is ClockVariable
+            }.stream().forEach { p: PortFmi3Api ->
+
+                val variable = p.scalarVariable.variable as ClockVariable
+
+                //get interval for all
+                //instance.getInterval
+                if (variable.interval != Fmi3ClockInterval.Triggered)
+                    instance.getClockInterval(builder.dynamicScope, p)
+
+                if (variable.interval == Fmi3ClockInterval.Constant || variable.interval == Fmi3ClockInterval.Fixed || variable.interval == Fmi3ClockInterval.Tunable) {
+//get shift
+                    instance.getClockShift(p)
+//                    instance.set(
+//                        p,
+//                        DoubleExpressionValue.of((p.scalarVariable.variable as ClockVariable).intervalDecimal!!)
+//                    )
+                }
+            }
+        })
+
         //Exit initialization Mode
         fmuInstances.values.forEach(Consumer { obj: ComponentVariableFmi2Api -> obj.exitInitializationMode() })
         fmu3Instances.values.forEach(Consumer { obj: InstanceVariableFmi3Api -> obj.exitInitializationMode() })
@@ -492,7 +551,7 @@ class Initializer : BasicMaestroExpansionPlugin {
         return try {
             val setting = MablApiBuilder.MablSettings()
             setting.fmiErrorHandlingEnabled = false
-            val builder = MablApiBuilder(setting, formalArguments[0])
+            val builder = ExpansionMableApiBuilder(setting, formalArguments[0])
             val dynamicScope = builder.dynamicScope
             val math = builder.mablToMablAPI.mathBuilder
             val booleanLogic = builder.mablToMablAPI.booleanBuilder
@@ -536,72 +595,6 @@ class Initializer : BasicMaestroExpansionPlugin {
                 booleanLogic,
                 math
             )
-//
-//            // Create bindings
-//            FromMaBLToMaBLAPI.createBindings(fmuInstances, env)
-//
-//            this.config = config as InitializationConfig
-//
-//            this.modelParameters = config.modelParameters
-//            this.envParameters = config.envParameters
-//
-//            // Convergence related variables
-//            absoluteTolerance = dynamicScope.store("absoluteTolerance", this.config!!.absoluteTolerance)
-//            relativeTolerance = dynamicScope.store("relativeTolerance", this.config!!.relativeTolerance)
-//            maxConvergeAttempts = dynamicScope.store("maxConvergeAttempts", this.config!!.maxIterations)
-//
-//            logger.debug("Setup experiment for all components")
-//            fmuInstances.values.forEach { i ->
-//                i.setupExperiment(
-//                    externalStartTime,
-//                    externalEndTime,
-//                    this.config!!.relativeTolerance
-//                )
-//            };
-//            val connections = createConnections(env, fmuInstances)
-//
-//            //Find the right order to instantiate dependentPorts and make sure where doesn't exist any cycles in the connections
-//            val instantiationOrder = topologicalPlugin.findInstantiationOrderStrongComponents(connections)
-//
-//
-//            //Set variables for all components in IniPhase
-//            setComponentsVariables(fmuInstances, PhasePredicates.iniPhase(), builder)
-//
-//            //Enter initialization Mode
-//            logger.debug("Enter initialization Mode")
-//            fmuInstances.values.forEach(Consumer { fmu: ComponentVariableFmi2Api -> fmu.enterInitializationMode() })
-//
-//            val instructions = instantiationOrder.map { i ->
-//                createInitInstructions(
-//                    i.toList(),
-//                    dynamicScope,
-//                    fmuInstances,
-//                    booleanLogic,
-//                    math
-//                )
-//            }
-//            var stabilisationScope: ScopeFmi2Api? = null
-//            var stabilisationLoop: IntVariableFmi2Api? = null
-//            if (this.config!!.stabilisation) {
-//                stabilisationLoop = dynamicScope.store("stabilisation_loop", this.config!!.maxIterations)
-//                stabilisationScope = dynamicScope.enterWhile(
-//                    stabilisationLoop!!.toMath().greaterThan(IntExpressionValue.of(0))
-//                )
-//            }
-//
-//            instructions.forEach { i -> i.perform() }
-//
-//            if (stabilisationScope != null) {
-//                stabilisationLoop!!.decrement();
-//                stabilisationScope.activate()
-//                stabilisationScope.leave();
-//            }
-//
-//
-//            setRemainingInputs(fmuInstances, builder)
-//
-//            //Exit initialization Mode
-//            fmuInstances.values.forEach(Consumer { obj: ComponentVariableFmi2Api -> obj.exitInitializationMode() })
 
             val algorithm = builder.buildRaw() as SBlockStm
             algorithm.apply(ToParExp())
@@ -640,6 +633,7 @@ class Initializer : BasicMaestroExpansionPlugin {
         fmuInstances: Map<String, InstanceVariableFmi3Api>, builder: MablApiBuilder
     ) {
         for (comp in fmuInstances.values) {
+
             try {
                 val scalarVariables = comp.modelDescription.getScalarVariables()
                 val inputsScalars = scalarVariables.filter { x ->
@@ -736,16 +730,16 @@ class Initializer : BasicMaestroExpansionPlugin {
                 Fmi3TypeEnum.BooleanType -> comp.set(port, BooleanExpressionValue.of(staticValue as Boolean))
                 Fmi3TypeEnum.Float64Type -> {
 
-                    if (port.scalarVariable.variable.isScalar()) {
+                    if (staticValue is List<*>) {
                         staticValue = (staticValue as List<Any>).get(0)
-
-
-                        if (staticValue is Int) {
-                            staticValue = staticValue.toDouble()
-                        }
-                        val b: Double = staticValue as Double
-                        comp.set(port, DoubleExpressionValue.of(b))
                     }
+
+                    if (staticValue is Int) {
+                        staticValue = staticValue.toDouble()
+                    }
+                    val b: Double = staticValue as Double
+                    comp.set(port, DoubleExpressionValue.of(b))
+
                 }
 
                 Fmi3TypeEnum.Int32Type -> comp.set(port, IntExpressionValue.of(staticValue as Int))
@@ -792,6 +786,18 @@ class Initializer : BasicMaestroExpansionPlugin {
         }
     }
 
+
+    private fun isOutputPort(p: RelationVariable): Boolean {
+        return p.has(Fmi2ModelDescription.Causality.Output) || p.has(Fmi3Causality.Output)
+    }
+
+    private fun isClockPort(p: RelationVariable): Boolean {
+
+        return p.getScalarVariable(Fmi3ModelDescription::Fmi3ScalarVariable::class.java) != null && p.type.hasType(
+            Fmi3TypeEnum.ClockType
+        )
+    }
+
     private fun createInitInstructions(
         ports: List<org.intocps.maestro.framework.fmi2.RelationVariable<Any>>,
         dynamicScope: DynamicActiveBuilderScope,
@@ -806,7 +812,7 @@ class Initializer : BasicMaestroExpansionPlugin {
         } else {
             val actions = ports.map { c -> fmuCoSimInstruction(fmuInstances, fmu3Instances, c) }
             val outputPorts =
-                ports.filter { p -> p.has(Fmi2ModelDescription.Causality.Output) || p.has(Fmi3Causality.Output) }
+                ports.filter { p -> isOutputPort(p) && !isClockPort(p) }
                     .map { i -> i }
             LoopSimInstruction(
                 dynamicScope,

--- a/plugins/initializer/src/main/kotlin/Initializer.kt
+++ b/plugins/initializer/src/main/kotlin/Initializer.kt
@@ -515,14 +515,32 @@ class Initializer : BasicMaestroExpansionPlugin {
 
                 val variable = p.scalarVariable.variable as ClockVariable
 
+
+                val sc =p.scalarVariable.variable as ClockVariable
+                if((variable.interval == Fmi3ClockInterval.Constant || variable.interval == Fmi3ClockInterval.Fixed || variable.interval == Fmi3ClockInterval.Tunable) && sc.intervalDecimal!=null) {
+                    instance.setClockInterval(
+                        builder.dynamicScope,
+                        p,
+                        DoubleExpressionValue.of(sc.intervalDecimal!!.toDouble())
+                    )
+                }
+
                 //get interval for all
                 //instance.getInterval
-                if (variable.interval != Fmi3ClockInterval.Triggered)
+                if (variable.interval != Fmi3ClockInterval.Triggered) {
                     instance.getClockInterval(builder.dynamicScope, p)
-
+                }
                 if (variable.interval == Fmi3ClockInterval.Constant || variable.interval == Fmi3ClockInterval.Fixed || variable.interval == Fmi3ClockInterval.Tunable) {
-//get shift
-                    instance.getClockShift(p)
+                //get shift
+                    val sc =p.scalarVariable.variable as ClockVariable
+                    if(sc.shiftDecimal!=null) {
+                        instance.setClockShift(
+                            builder.dynamicScope,
+                            p,
+                            DoubleExpressionValue.of(sc.shiftDecimal!!.toDouble())
+                        )
+                    }
+                        instance.getClockShift(builder.dynamicScope, p)
 //                    instance.set(
 //                        p,
 //                        DoubleExpressionValue.of((p.scalarVariable.variable as ClockVariable).intervalDecimal!!)

--- a/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/IdentifierReplacer.java
+++ b/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/IdentifierReplacer.java
@@ -1,6 +1,7 @@
 package org.intocps.maestro.plugin;
 
 import org.intocps.maestro.ast.LexIdentifier;
+import org.intocps.maestro.ast.LexLocation;
 import org.intocps.maestro.ast.analysis.AnalysisException;
 import org.intocps.maestro.ast.analysis.DepthFirstAnalysisAdaptor;
 import org.intocps.maestro.ast.node.AFieldExp;
@@ -48,7 +49,7 @@ class IdentifierReplacer {
         public void caseAIdentifierExp(AIdentifierExp node) throws AnalysisException {
             for (Map.Entry<String, String> replacing : old2New.entrySet()) {
                 if (node.getName().getText().equals(replacing.getKey())) {
-                    node.parent().replaceChild(node, new AIdentifierExp(new LexIdentifier(replacing.getValue(), null)));
+                    node.parent().replaceChild(node, new AIdentifierExp(new LexLocation("",0,0),new LexIdentifier(replacing.getValue(), null)));
                 }
             }
         }

--- a/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/JacobianInternalBuilder.java
+++ b/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/JacobianInternalBuilder.java
@@ -37,6 +37,7 @@ class JacobianInternalBuilder {
     public static class Jacobian3Context extends BaseJacobianContext {
         Map<String, InstanceVariableFmi3Api> fmu3Instances;
         BooleanVariableFmi2Api terminateSimulation;
+        BooleanVariableFmi2Api eventMode;
     }
 
     static <T extends BaseJacobianContext> T buildBaseCtxt(T ctxt, IndexedFunctionDeclarationContainer<JacobianStepBuilder.ARG_INDEX> selectedFun,
@@ -97,20 +98,8 @@ class JacobianInternalBuilder {
         ctxt.stepSizes = new ArrayVariableFmi2Api<>(stepSizesTmp.getDeclaringStm(), stepSizesTmp.getType(), stepSizesTmp.getDeclaredScope(), dynamicScope,
                 stepSizesTmp.getDesignator(), stepSizesTmp.getReferenceExp(), items);
         ctxt.terminateSimulation = dynamicScope.store("terminateSimulation", false);
+        ctxt.eventMode = dynamicScope.store("eventMode", false);
 
-//        if(totalTimeBasedClocks>1) {
-//            // preconfigure the step size to the shift only if we have clocks
-//            int clockIndex = 1;
-//            ctxt.stepSizes.items().getFirst().setValue(ctxt.stepSize);
-//            for (var instance : ctxt.fmu3Instances.entrySet()) {
-//                var clockTimePorts = instance.getValue().getPorts().stream().filter(isClockTimeBased).toList();
-//                for (var clockPort : clockTimePorts) {
-//                    ctxt.stepSizes.items().get(clockIndex++).setValue(instance.getValue().getClocksUtil().getShift(clockPort));
-//                }
-//            }
-//
-//            ctxt.currentStepSize.setValue(builder.getMathBuilder().minRealFromArray(ctxt.stepSizes));
-//        }
         return ctxt;
 
     }

--- a/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/JacobianInternalBuilder.java
+++ b/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/JacobianInternalBuilder.java
@@ -2,17 +2,21 @@ package org.intocps.maestro.plugin;
 
 import org.intocps.maestro.ast.node.PStm;
 import org.intocps.maestro.framework.fmi2.api.FmiBuilder;
+import org.intocps.maestro.framework.fmi2.api.mabl.MablApiBuilder;
 import org.intocps.maestro.framework.fmi2.api.mabl.scoping.DynamicActiveBuilderScope;
-import org.intocps.maestro.framework.fmi2.api.mabl.variables.BooleanVariableFmi2Api;
-import org.intocps.maestro.framework.fmi2.api.mabl.variables.ComponentVariableFmi2Api;
-import org.intocps.maestro.framework.fmi2.api.mabl.variables.DoubleVariableFmi2Api;
+import org.intocps.maestro.framework.fmi2.api.mabl.variables.*;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static org.intocps.maestro.ast.MableAstFactory.*;
+import static org.intocps.maestro.framework.fmi2.api.mabl.PortFmi3Api.PortFilters.isClockTimeBased;
 import static org.intocps.maestro.plugin.JacobianStepBuilder.ARG_INDEX.*;
 
 class JacobianInternalBuilder {
@@ -21,6 +25,7 @@ class JacobianInternalBuilder {
         DoubleVariableFmi2Api externalStepSize;
         DoubleVariableFmi2Api currentStepSize;
         DoubleVariableFmi2Api stepSize;
+        ArrayVariableFmi2Api<DoubleVariableFmi2Api> stepSizes;
         DoubleVariableFmi2Api externalStartTime;
         DoubleVariableFmi2Api currentCommunicationTime;
         DoubleVariableFmi2Api externalEndTime;
@@ -28,29 +33,84 @@ class JacobianInternalBuilder {
         DoubleVariableFmi2Api endTime;
         Map<String, ComponentVariableFmi2Api> fmuInstances;
     }
-    static BaseJacobianContext buildBaseCtxt(IndexedFunctionDeclarationContainer<JacobianStepBuilder.ARG_INDEX> selectedFun, List<FmiBuilder.Variable<PStm, ?>> formalArguments, DynamicActiveBuilderScope dynamicScope) {
-        BaseJacobianContext ctxt = new BaseJacobianContext();
+
+    public static class Jacobian3Context extends BaseJacobianContext {
+        Map<String, InstanceVariableFmi3Api> fmu3Instances;
+        BooleanVariableFmi2Api terminateSimulation;
+    }
+
+    static <T extends BaseJacobianContext> T buildBaseCtxt(T ctxt, IndexedFunctionDeclarationContainer<JacobianStepBuilder.ARG_INDEX> selectedFun,
+                                                           List<FmiBuilder.Variable<PStm, ?>> formalArguments, DynamicActiveBuilderScope dynamicScope) {
         // Convert raw MaBL to API
         ctxt.externalStepSize = (DoubleVariableFmi2Api) selectedFun.getArgumentValue(formalArguments, STEP_SIZE);
-        ctxt.currentStepSize = dynamicScope.store("jac_current_step_size", 0.0);
-        ctxt.stepSize = dynamicScope.store("jac_step_size", 0.0);
+
+        ctxt.currentStepSize = dynamicScope.store("jac_current_step_size", ctxt.externalStepSize);
+        ctxt.stepSize = dynamicScope.store("jac_step_size", ctxt.externalStepSize);
+
         ctxt.externalStartTime = (DoubleVariableFmi2Api) selectedFun.getArgumentValue(formalArguments, START_TIME);
         dynamicScope.addTransferAs(ctxt.externalStartTime.getName());
-        ctxt.currentCommunicationTime = dynamicScope.store("jac_current_communication_point", 0.0);
+        ctxt.currentCommunicationTime = dynamicScope.store("jac_current_communication_point", ctxt.externalStartTime);
         ctxt.externalEndTime = (DoubleVariableFmi2Api) selectedFun.getArgumentValue(formalArguments, END_TIME);
         ctxt.externalEndTimeDefined = (BooleanVariableFmi2Api) selectedFun.getArgumentValue(formalArguments, END_TIME_DEFINED);
-        ctxt.endTime = dynamicScope.store("jac_end_time", 0.0);
+        ctxt.endTime = dynamicScope.store("jac_end_time", ctxt.externalEndTime);
 
-        ctxt.currentStepSize.setValue(ctxt.externalStepSize);
-        ctxt.stepSize.setValue(ctxt.externalStepSize);
-        ctxt.currentCommunicationTime.setValue(ctxt.externalStartTime);
-        ctxt.endTime.setValue(ctxt.externalEndTime);
+//        ctxt.currentStepSize.setValue(ctxt.externalStepSize);
+//        ctxt.stepSize.setValue(ctxt.externalStepSize);
+//        ctxt.currentCommunicationTime.setValue(ctxt.externalStartTime);
+//        ctxt.endTime.setValue(ctxt.externalEndTime);
 
         // Get FMU instances - use LinkedHashMap to preserve added order
         ctxt.fmuInstances =
                 ((List<ComponentVariableFmi2Api>) ((FmiBuilder.ArrayVariable) selectedFun.getArgumentValue(formalArguments, FMI2_INSTANCES)).items()).stream()
                         .collect(Collectors.toMap(ComponentVariableFmi2Api::getName, Function.identity(), (u, v) -> u, LinkedHashMap::new));
 
+        return ctxt;
+
+    }
+
+    static BaseJacobianContext buildBaseCtxt(IndexedFunctionDeclarationContainer<JacobianStepBuilder.ARG_INDEX> selectedFun,
+                                             List<FmiBuilder.Variable<PStm, ?>> formalArguments, DynamicActiveBuilderScope dynamicScope) {
+        return buildBaseCtxt(new BaseJacobianContext(), selectedFun, formalArguments, dynamicScope);
+    }
+
+    static Jacobian3Context buildBaseFmi3Ctxt(MablApiBuilder builder, IndexedFunctionDeclarationContainer<JacobianStepBuilder.ARG_INDEX> selectedFun,
+                                              List<FmiBuilder.Variable<PStm, ?>> formalArguments, DynamicActiveBuilderScope dynamicScope
+    ) throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+        var ctxt = buildBaseCtxt(new Jacobian3Context(), selectedFun, formalArguments, dynamicScope);
+        // Get FMU instances - use LinkedHashMap to preserve added order
+        ctxt.fmu3Instances =
+                ((List<InstanceVariableFmi3Api>) ((FmiBuilder.ArrayVariable) selectedFun.getArgumentValue(formalArguments, FMI3_INSTANCES)).items()).stream()
+                        .collect(Collectors.toMap(InstanceVariableFmi3Api::getName, Function.identity(), (u, v) -> u, LinkedHashMap::new));
+
+//        ctxt.fmu3Instances.entrySet().stream().map(inst->inst.getValue().)
+        var totalTimeBasedClocks = Float.valueOf(
+                ctxt.fmu3Instances.values().stream().flatMap(inst -> inst.getPorts().stream().filter(isClockTimeBased)).count()).intValue()+1/*we store the fixed step at 0*/;
+        var totalTimeBasedClocksVar = dynamicScope.store("totalClockSizes", totalTimeBasedClocks);
+
+       var stepSizesTmp = dynamicScope.createArray("stepSizes", DoubleVariableFmi2Api.class, totalTimeBasedClocksVar);
+
+       var items = IntStream.range(0, totalTimeBasedClocks)
+                .mapToObj(i -> new VariableFmi2Api<DoubleVariableFmi2Api>(stepSizesTmp.getDeclaringStm(),stepSizesTmp.getType(), stepSizesTmp.getDeclaredScope(), dynamicScope,
+                        newAArayStateDesignator(newAIdentifierStateDesignator(newAIdentifier("stepSizes")), newAIntLiteralExp(i)),
+                        newAArrayIndexExp(newAIdentifierExp("stepSizes"), Collections.singletonList(newAIntLiteralExp(i))))).collect(Collectors.toList());
+
+        ctxt.stepSizes = new ArrayVariableFmi2Api<>(stepSizesTmp.getDeclaringStm(), stepSizesTmp.getType(), stepSizesTmp.getDeclaredScope(), dynamicScope,
+                stepSizesTmp.getDesignator(), stepSizesTmp.getReferenceExp(), items);
+        ctxt.terminateSimulation = dynamicScope.store("terminateSimulation", false);
+
+//        if(totalTimeBasedClocks>1) {
+//            // preconfigure the step size to the shift only if we have clocks
+//            int clockIndex = 1;
+//            ctxt.stepSizes.items().getFirst().setValue(ctxt.stepSize);
+//            for (var instance : ctxt.fmu3Instances.entrySet()) {
+//                var clockTimePorts = instance.getValue().getPorts().stream().filter(isClockTimeBased).toList();
+//                for (var clockPort : clockTimePorts) {
+//                    ctxt.stepSizes.items().get(clockIndex++).setValue(instance.getValue().getClocksUtil().getShift(clockPort));
+//                }
+//            }
+//
+//            ctxt.currentStepSize.setValue(builder.getMathBuilder().minRealFromArray(ctxt.stepSizes));
+//        }
         return ctxt;
 
     }

--- a/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/JacobianStepBuilder3.java
+++ b/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/JacobianStepBuilder3.java
@@ -1,6 +1,7 @@
 package org.intocps.maestro.plugin;
 
 import org.intocps.maestro.ast.AFunctionDeclaration;
+import org.intocps.maestro.ast.LexLocation;
 import org.intocps.maestro.ast.MableAstFactory;
 import org.intocps.maestro.ast.node.*;
 import org.intocps.maestro.core.Framework;
@@ -28,10 +29,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.intocps.maestro.ast.MableAstFactory.*;
+import static org.intocps.maestro.framework.fmi2.api.mabl.PortFmi3Api.PortFilters.*;
 import static org.intocps.maestro.plugin.JacobianStepBuilder.ARG_INDEX.*;
 
 @SimulationFramework(framework = Framework.FMI2)
 public class JacobianStepBuilder3 extends JacobianStepBuilder {
+
 
     final static Logger logger = LoggerFactory.getLogger(JacobianStepBuilder3.class);
 
@@ -102,13 +105,11 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
                 settings.setGetDerivatives = jacobianStepConfig.setGetDerivatives;
             }
 
-            if (!(parentBuilder instanceof MablApiBuilder)) {
+            if (!(parentBuilder instanceof MablApiBuilder builder)) {
                 throw new ExpandException(
                         "Not supporting the given builder type. Expecting " + MablApiBuilder.class.getSimpleName() + " got " + parentBuilder.getClass()
                                 .getSimpleName());
             }
-
-            MablApiBuilder builder = (MablApiBuilder) parentBuilder;
 
             DynamicActiveBuilderScope dynamicScope = builder.getDynamicScope();
             MathBuilderFmi2Api math = builder.getMablToMablAPI().getMathBuilder();
@@ -163,7 +164,7 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
             Map<StringVariableFmi2Api, ComponentVariableFmi2Api> fmuNamesToFmuInstances = new LinkedHashMap<>();
 
             ArrayVariableFmi2Api<Double> fmuCommunicationPoints = dynamicScope.store("fmu_communicationpoints",
-                    new Double[fmuInstances.entrySet().size() + fmuInstances3.entrySet().size()]);
+                    new Double[fmuInstances.size() + fmuInstances3.size()]);
 
 //            int indexer = 0;
             for (ComponentVariableFmi2Api instance : fmuInstances.values()) {
@@ -181,10 +182,10 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
             }
 
             AtomicInteger indexer = new AtomicInteger();
-            Map<ComponentVariableFmi2Api, VariableFmi2Api<Double>> fmuInstanceToCommunicationPoint = fmuInstances.values().stream()
+           var fmuInstanceToCommunicationPoint = fmuInstances.values().stream()
                     .collect(Collectors.toMap(inst -> inst, instance -> fmuCommunicationPoints.items().get(indexer.getAndIncrement())));
 
-            Map<InstanceVariableFmi3Api, VariableFmi2Api<Double>> fmuInstance3ToCommunicationPoint = fmuInstances3.values().stream()
+            var fmuInstance3ToCommunicationPoint = fmuInstances3.values().stream()
                     .collect(Collectors.toMap(inst -> inst, instance -> fmuCommunicationPoints.items().get(indexer.getAndIncrement())));
 
 
@@ -214,6 +215,30 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
             if (algorithm == StepAlgorithm.VARIABLESTEP) {
                 varStep = JacobianVariableStepBuilder.init(ctxt, jacobianStepConfig, dynamicScope, builder, fmuNamesToFmuInstances);
             }
+
+            // TODO: we need to handle the initial event loop for clocks
+
+            // Event Step 0: create time based clocks. We need to obtain the specific timing variables from
+//            fmuInstances3.values().stream().findFirst().get().
+
+            // Event Init step 1: get clocks from others
+            for(var instance : fmuInstances3.values()) {
+                instance.enterEventMode();
+                var clockPorts =instance.getPorts().stream().filter(isClock).toList();
+                clockPorts.stream().filter(isCausalityOutput).forEach(p-> instance.getAndShare(p));
+            }
+
+            // Event update the initial event states not sure if we should set clocks before this
+
+
+
+
+            //we need to make sure every instance is ready for step mode
+            for(var instance : fmuInstances3.values()) {
+                instance.enterStepMode();
+            }
+
+            //TODO: OK now clocked variables must be filtered as they are only available in event mode
 
             // Log values at t = start time
             dataWriterInstance.log(ctxt.currentCommunicationTime);
@@ -267,7 +292,7 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
                 // SET ALL LINKED VARIABLES
                 // This has to be carried out regardless of stabilisation or not.
                 ModelSwapBuilder.setWithModelSwapLinking(fmuInstances, env, dynamicScope, modelSwapContext);
-                fmuInstances3.values().forEach(instance -> instance.setLinked());
+                fmuInstances3.values().forEach( instance -> instance.setLinked(instance.getPorts().stream().filter(InstanceVariableFmi3Api.isLinked.and(isClockedVariable.negate()).and(isClock.negate())).toArray(PortFmi3Api[]::new)));
 
                 if (algorithm == StepAlgorithm.VARIABLESTEP) {
                     // Get variable step
@@ -325,8 +350,8 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
 
 //                    stepPredicate.ifPresent(dynamicScope::enterIf);
 
-                    Map.Entry<FmiBuilder.BoolVariable<PStm>, InstanceVariableFmi3Api.StepResult> discard = instance.step(builder.getDynamicScope(),
-                            communicationTime, ctxt.currentStepSize, new ABoolLiteralExp(false));
+                    var discard = instance.step(builder.getDynamicScope(),
+                            communicationTime, ctxt.currentStepSize, new ABoolLiteralExp(new LexLocation("",0,0),false));
 
                     communicationPoint.setValue(new DoubleExpressionValue(discard.getValue().getLastSuccessfulTime().getExp()));
 
@@ -349,17 +374,17 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
                 });
 
                 // GET ALL LINKED OUTPUTS INCLUDING LOGGING OUTPUTS
-                for (Map.Entry<ComponentVariableFmi2Api, Map<PortFmi2Api, VariableFmi2Api<Object>>> entry : componentsToPortsWithValues.entrySet()) {
-                    Map<PortFmi2Api, VariableFmi2Api<Object>> portsToValues = entry.getValue();
+                for (var entry : componentsToPortsWithValues.entrySet()) {
+                    var portsToValues = entry.getValue();
                     portsToValues = entry.getKey().get(portsToValues.keySet().toArray(PortFmi2Api[]::new));
                 }
-                for (Map.Entry<InstanceVariableFmi3Api, Map<PortFmi3Api, VariableFmi2Api<Object>>> entry : instancesToPortsWithValues.entrySet()) {
-                    Map<PortFmi3Api, VariableFmi2Api<Object>> portsToValues = entry.getValue();
+                for (var entry : instancesToPortsWithValues.entrySet()) {
+                    var portsToValues = entry.getValue();
 
                     InstanceVariableFmi3Api instance = entry.getKey();
 
-                    for (PortFmi3Api p : portsToValues.keySet().toArray(PortFmi3Api[]::new)) {
-                        Map<PortFmi3Api, VariableFmi2Api<Object>> val = instance.get(p);
+                    for (PortFmi3Api p : portsToValues.keySet().stream().filter(isClockedVariable.negate()).toArray(PortFmi3Api[]::new)) {
+                        var val = instance.get(p);
                         instance.share(val);
                     }
 

--- a/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/JacobianStepBuilder3.java
+++ b/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/JacobianStepBuilder3.java
@@ -7,6 +7,7 @@ import org.intocps.maestro.ast.node.*;
 import org.intocps.maestro.core.Framework;
 import org.intocps.maestro.core.dto.StepAlgorithm;
 import org.intocps.maestro.core.messages.IErrorReporter;
+import org.intocps.maestro.fmi.fmi3.Fmi3Variable;
 import org.intocps.maestro.framework.core.FrameworkUnitInfo;
 import org.intocps.maestro.framework.core.ISimulationEnvironment;
 import org.intocps.maestro.framework.fmi2.ComponentInfo;
@@ -152,6 +153,7 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
                     .map(clockPort -> new DataWriter.DataWriterInstance.LogEntry(clockPort.getMultiModelScalarVariableName(),
                             () -> m.getKey().getClocksUtil().getClockTriggeredState(clockPort).getReferenceExp().clone()))).toList();
             logVariables.addAll(timeBasedClocksLogVariables);
+            logVariables.addFirst(new DataWriter.DataWriterInstance.LogEntry("eventMode", () -> ctxt.eventMode.getReferenceExp().clone()));
             dataWriterInstance.initialize(logVariables);
 
             // Create simulation control to allow for user interactive loop stopping
@@ -228,7 +230,7 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
             builder.getLogger().debug(blockMessage("Jaccobian Event handling before loop"));
             builder.getLogger().debug("EVENT - Before step event handling");
             var eventCapableInstances = fmuInstances3.values().stream().filter(hasEventMode).toList();
-            var eventUpdatingFlags = updateEventsInEventMode(builder, eventCapableInstances, fmuInstances3, ctxt);
+            var eventUpdatingFlags = updateEventsInEventMode(builder, eventCapableInstances, fmuInstances3, dataWriterInstance, ctxt);
 
             //TODO: OK now clocked variables must be filtered as they are only available in event mode
 
@@ -363,7 +365,7 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
 
                     // Log values at current communication point
                     dataWriterInstance.log(ctxt.currentCommunicationTime);
-                    eventUpdatingFlags = updateEventsInEventMode(builder, eventCapableInstances, fmuInstances3, ctxt);
+                    eventUpdatingFlags = updateEventsInEventMode(builder, eventCapableInstances, fmuInstances3, dataWriterInstance, ctxt);
 
 
                     ctxt.currentStepSize.setValue(calculateNextStepSize(builder, ctxt, timeBasedInputClockPorts));
@@ -414,7 +416,7 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
                 InstanceClocksFmi3 clocks = instance.getValue().getClocksUtil();
 
                 stepSizeVar.setValue(clocks.getTimeToTick(ctxt.currentCommunicationTime.toMath(), clockPort));
-                builder.getLogger().debug("## StepSizes["+(clockIndex-1)+"]: %s", stepSizeVar);
+                builder.getLogger().debug("## StepSizes[" + (clockIndex - 1) + "]: %s", stepSizeVar);
             }
         }
         builder.getLogger().debug("## current time: %s", ctxt.currentCommunicationTime);
@@ -427,8 +429,10 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
     private static Map<String, BooleanVariableFmi2Api> updateEventsInEventMode(MablApiBuilder builder,
                                                                                List<InstanceVariableFmi3Api> eventCapableInstances,
                                                                                Map<String, InstanceVariableFmi3Api> fmuInstances3,
+                                                                               DataWriter.DataWriterInstance dataWriterInstance,
                                                                                JacobianInternalBuilder.Jacobian3Context ctxt) {
         eventCapableInstances.forEach(InstanceVariableFmi3Api::enterEventMode);
+        ctxt.eventMode.setValue(BooleanExpressionValue.of(true));
         var eventUpdatingFlags = fmuInstances3.entrySet().stream().filter(map -> hasEventMode.test(map.getValue()))
                 .collect(Collectors.toMap(Map.Entry::getKey, map -> builder.getDynamicScope().store(map.getKey() + "ProcessEvents", true)));
         builder.getLogger().debug("EVENT - Get and Share clocks");
@@ -448,38 +452,68 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
                  */
 
 
-        processEvents(builder, eventCapableInstances, ctxt, eventUpdatingFlags, fmuInstances3);
+        processEvents(builder, eventCapableInstances, eventUpdatingFlags, dataWriterInstance, fmuInstances3, ctxt);
 
 
         //we need to make sure every instance is ready for step mode
         eventCapableInstances.forEach(InstanceVariableFmi3Api::enterStepMode);
+        ctxt.eventMode.setValue(BooleanExpressionValue.of(false));
         return eventUpdatingFlags;
     }
 
     private static void processEvents(MablApiBuilder builder, List<InstanceVariableFmi3Api> eventCapableInstances,
-                                      JacobianInternalBuilder.Jacobian3Context ctxt,
-                                      Map<String, BooleanVariableFmi2Api> eventUpdatingFlags, Map<String, InstanceVariableFmi3Api> fmuInstances3) {
+                                      Map<String, BooleanVariableFmi2Api> eventUpdatingFlags, DataWriter.DataWriterInstance dataWriterInstance,
+                                      Map<String, InstanceVariableFmi3Api> fmuInstances3, JacobianInternalBuilder.Jacobian3Context ctxt) {
         var eventHandlingScope = builder.getDynamicScope().enterScope();
 
-        updateTriggeredClocks(eventCapableInstances);
+        updateTriggeredClocks(builder, eventCapableInstances);
         updateTimeBasedClocks(builder, eventCapableInstances, ctxt);
 
-        updateEventStates(builder, eventUpdatingFlags, fmuInstances3, ctxt);
+        updateEventStates(builder, eventUpdatingFlags, fmuInstances3, dataWriterInstance, ctxt);
 
 
         // Event update the initial event states not sure if we should set clocks before this
         // set shared clocks
         // set time based clocks that are not shifted yes
         //FMI3UpdateDiscreteStates
+        deactivateAllClocks(builder, eventCapableInstances, ctxt);
 
         eventHandlingScope.leave();
     }
 
-    private static void updateTriggeredClocks(List<InstanceVariableFmi3Api> eventCapableInstances) {
+    private static void deactivateAllClocks(MablApiBuilder builder, List<InstanceVariableFmi3Api> eventCapableInstances,
+                                            JacobianInternalBuilder.Jacobian3Context ctxt) {
+        builder.getLogger().debug("EVENT - Deactivated all clocks");
+        eventCapableInstances.forEach(
+                instance -> instance.getPorts().stream().filter(isClock).filter(isCausalityOutput.and(isClockTriggered))
+                        .forEach(port -> port.getSharedAsVariable().setValue(new BooleanExpressionValue(false))));
+
+        eventCapableInstances.forEach(
+                instance -> instance.getPorts().stream().filter(isClock).filter(isClockTimeBased).forEach(port ->
+                        instance.getClocksUtil().deactivate(port)));
+        builder.getDynamicScope().add(new ADebugStm(Collections.singletonList(new AStringLiteralExp(null, "context"))));
+    }
+
+    private static void updateTriggeredClocks(MablApiBuilder builder, List<InstanceVariableFmi3Api> eventCapableInstances) {
         //get all triggered output clocks and make them available
+        builder.getLogger().debug("Processing clock (triggered clocks)");
         //noinspection unchecked
         eventCapableInstances.forEach(
-                instance -> instance.getPorts().stream().filter(isClock).filter(isCausalityOutput.and(isClockTriggered)).forEach(instance::getAndShare));
+                instance -> {
+                    var variables = instance.getPorts().stream().filter(isClock).filter(isCausalityOutput.and(isClockTriggered)).map(instance::getAndShare)
+                            .toList();
+                    // for each potentially triggered output clock we need to get, share and set linked
+                    for (var variable : variables) {
+                        for (var clockValueRef : variable.entrySet()) {
+                            if (clockValueRef.getKey() instanceof PortFmi3Api clockPort && clockValueRef.getValue() instanceof VariableFmi2Api clockVar) {
+
+                                var ifTriggeredScope = builder.getDynamicScope().enterIf(new PredicateFmi2Api(clockVar.getReferenceExp()));
+                                synchronizeLinkedClockDependentVariables(instance, clockPort);
+                                ifTriggeredScope.leave();
+                            }
+                        }
+                    }
+                });
         //set all triggered input clocks
         eventCapableInstances.forEach(
                 instance -> instance.getPorts().stream().filter(isClock).filter(isCausalityInput.and(isClockTriggered)).forEach(instance::setLinked));
@@ -594,13 +628,15 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
     }
 
     private static void updateEventStates(MablApiBuilder builder, Map<String, BooleanVariableFmi2Api> eventUpdatingFlags,
-                                          Map<String, InstanceVariableFmi3Api> fmuInstances3, JacobianInternalBuilder.Jacobian3Context ctxt) {
+                                          Map<String, InstanceVariableFmi3Api> fmuInstances3, DataWriter.DataWriterInstance dataWriterInstance,
+                                          JacobianInternalBuilder.Jacobian3Context ctxt) {
         var dontCareBool = builder.getDynamicScope().store("dont_care_bool", false);
         var dontCareReal = builder.getDynamicScope().store("dont_care_real", 0.0);
 
         // keep looping while any of needs an update
-        builder.getDynamicScope()
+        var updateWhile = builder.getDynamicScope()
                 .enterWhile(eventUpdatingFlags.values().stream().map(BooleanVariableFmi2Api::toPredicate).reduce(PredicateFmi2Api::or).orElse(null));
+        dataWriterInstance.log(ctxt.currentCommunicationTime);
 
         for (var entry : eventUpdatingFlags.entrySet()) {
             var k = entry.getKey();
@@ -617,6 +653,19 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
             //TODO check for terminate simulation
 
             processEventsScope.leave();
+        }
+        updateWhile.leave();
+    }
+
+    private static void synchronizeLinkedClockDependentVariables(InstanceVariableFmi3Api instance, PortFmi3Api clockPort) {
+        try {
+            var dependedClockVariables = instance.getModelDescription().getModelVariables().stream()
+                    .filter(sv -> sv.getClocksAsLong() != null && sv.getClocksAsLong().contains(clockPort.getPortReferenceValue())).map(
+                            Fmi3Variable::getName).toList().toArray(String[]::new);
+            instance.getAndShare(dependedClockVariables);
+            instance.setLinked(dependedClockVariables);
+        } catch (XPathExpressionException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -641,7 +690,8 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
                         .enterIf(instance.getClocksUtil().check(builder.getDynamicScope(), ctxt.currentCommunicationTime.toMath(), clockPort));
                 builder.getLogger().debug("\tTimed clock of %s.%s TRIGGERED".formatted(instance.getName(), clockPort.getName()));
                 instance.set(clockPort, BooleanExpressionValue.of(true));
-                builder.getDynamicScope().add(new ADebugStm(Collections.singletonList(new AStringLiteralExp(null,"context"))));
+                synchronizeLinkedClockDependentVariables(instance, clockPort);
+                builder.getDynamicScope().add(new ADebugStm(Collections.singletonList(new AStringLiteralExp(null, "context"))));
                 ifScope.leave();
 
             });

--- a/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/JacobianStepBuilder3.java
+++ b/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/JacobianStepBuilder3.java
@@ -16,22 +16,26 @@ import org.intocps.maestro.framework.fmi2.api.mabl.*;
 import org.intocps.maestro.framework.fmi2.api.mabl.scoping.DynamicActiveBuilderScope;
 import org.intocps.maestro.framework.fmi2.api.mabl.scoping.IfMaBlScope;
 import org.intocps.maestro.framework.fmi2.api.mabl.scoping.ScopeFmi2Api;
+import org.intocps.maestro.framework.fmi2.api.mabl.values.BooleanExpressionValue;
 import org.intocps.maestro.framework.fmi2.api.mabl.values.DoubleExpressionValue;
+import org.intocps.maestro.framework.fmi2.api.mabl.values.IntExpressionValue;
 import org.intocps.maestro.framework.fmi2.api.mabl.variables.*;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.xml.xpath.XPathExpressionException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.intocps.maestro.ast.MableAstFactory.*;
 import static org.intocps.maestro.framework.fmi2.api.mabl.PortFmi3Api.PortFilters.*;
+import static org.intocps.maestro.framework.fmi2.api.mabl.variables.InstanceVariableFmi3Api.hasEventMode;
 import static org.intocps.maestro.plugin.JacobianStepBuilder.ARG_INDEX.*;
 
+@SuppressWarnings("deprecation")
 @SimulationFramework(framework = Framework.FMI2)
 public class JacobianStepBuilder3 extends JacobianStepBuilder {
 
@@ -55,6 +59,10 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
         return Collections.singletonList(fixedStep3Func);
     }
 
+    private String blockMessage(String msg) {
+        String seperator = "#############################################";
+        return seperator + "## " + msg + " " + seperator;
+    }
 
     @Override
     public <R> RuntimeConfigAddition<R> expandWithRuntimeAddition(AFunctionDeclaration declaredFunction,
@@ -121,24 +129,30 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
             }
 
             // Convert raw MaBL to API
-            JacobianInternalBuilder.BaseJacobianContext ctxt = JacobianInternalBuilder.buildBaseCtxt(selectedFun, formalArguments, dynamicScope);
+            var ctxt = JacobianInternalBuilder.buildBaseFmi3Ctxt(builder, selectedFun, formalArguments, dynamicScope);
 
-            Map<String, ComponentVariableFmi2Api> fmuInstances = ctxt.fmuInstances;
-            Map<String, InstanceVariableFmi3Api> fmuInstances3 = ((List<InstanceVariableFmi3Api>) ((FmiBuilder.ArrayVariable) selectedFun.getArgumentValue(
-                    formalArguments, FMI3_INSTANCES)).items()).stream()
-                    .collect(Collectors.toMap(InstanceVariableFmi3Api::getName, Function.identity(), (u, v) -> u, LinkedHashMap::new));
+            var fmuInstances = ctxt.fmuInstances;
+            var fmuInstances3 = ctxt.fmu3Instances;
+
+            var timeBasedInputClockPorts = fmuInstances3.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue,
+                    m -> m.getValue().getPorts().stream().filter(isClock).filter(isCausalityInput.and(isClockTimeBased))));
 
 
             // Create the logging
             DataWriter dataWriter = builder.getDataWriter();
             DataWriter.DataWriterInstance dataWriterInstance = dataWriter.createDataWriterInstance();
-            dataWriterInstance.initialize(Stream.concat(fmuInstances.values().stream().flatMap(x -> x.getVariablesToLog().stream()
+            List<DataWriter.DataWriterInstance.LogEntry> logVariables = Stream.concat(fmuInstances.values().stream().flatMap(x -> x.getVariablesToLog().stream()
                     .map(xsv -> new DataWriter.DataWriterInstance.LogEntry(xsv.getMultiModelScalarVariableName(),
                             () -> xsv.getSharedAsVariable().getReferenceExp().clone()))), fmuInstances3.values().stream().flatMap(
                     x -> x.getVariablesToLog().stream().map(xsv -> new DataWriter.DataWriterInstance.LogEntry(xsv.getMultiModelScalarVariableName(),
                             () -> xsv.getSharedAsVariable().getReferenceExp().clone())))
 
-            ).collect(Collectors.toList()));
+            ).collect(Collectors.toList());
+            var timeBasedClocksLogVariables = timeBasedInputClockPorts.entrySet().stream().flatMap(m -> m.getValue()
+                    .map(clockPort -> new DataWriter.DataWriterInstance.LogEntry(clockPort.getMultiModelScalarVariableName(),
+                            () -> m.getKey().getClocksUtil().getClockTriggeredState(clockPort).getReferenceExp().clone()))).toList();
+            logVariables.addAll(timeBasedClocksLogVariables);
+            dataWriterInstance.initialize(logVariables);
 
             // Create simulation control to allow for user interactive loop stopping
             SimulationControl simulationControl = builder.getSimulationControl();
@@ -155,6 +169,7 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
             Map<InstanceVariableFmi3Api, Map<PortFmi3Api, VariableFmi2Api<Object>>> instancesToPortsWithValues = JacobianVariableStepBuilder.getAllInstancePortsWithOutputOrLog(
                     fmuInstances3, jacobianStepConfig, env);
 
+            builder.getLogger().debug(blockMessage("Jaccobian start"));
 
             // Share
             componentsToPortsWithValues.forEach(ComponentVariableFmi2Api::share);
@@ -166,7 +181,6 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
             ArrayVariableFmi2Api<Double> fmuCommunicationPoints = dynamicScope.store("fmu_communicationpoints",
                     new Double[fmuInstances.size() + fmuInstances3.size()]);
 
-//            int indexer = 0;
             for (ComponentVariableFmi2Api instance : fmuInstances.values()) {
 
                 FrameworkUnitInfo v = env.getInstanceByLexName(instance.getEnvironmentName());
@@ -182,7 +196,7 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
             }
 
             AtomicInteger indexer = new AtomicInteger();
-           var fmuInstanceToCommunicationPoint = fmuInstances.values().stream()
+            var fmuInstanceToCommunicationPoint = fmuInstances.values().stream()
                     .collect(Collectors.toMap(inst -> inst, instance -> fmuCommunicationPoints.items().get(indexer.getAndIncrement())));
 
             var fmuInstance3ToCommunicationPoint = fmuInstances3.values().stream()
@@ -190,19 +204,7 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
 
 
             // validate if all fmus can get state
-            boolean everyFMUSupportsGetState = fmuInstances.values().stream().allMatch(inst -> {
-                try {
-                    return inst.getModelDescription().getCanGetAndSetFmustate();
-                } catch (XPathExpressionException e) {
-                    throw new RuntimeException(e);
-                }
-            }) && fmuInstances3.values().stream().allMatch(inst -> {
-                try {
-                    return inst.getModelDescription().getCanGetAndSetFmustate();
-                } catch (XPathExpressionException e) {
-                    throw new RuntimeException(e);
-                }
-            });
+            boolean everyFMUSupportsGetState = isEveryFMUSupportsGetState(fmuInstances, fmuInstances3);
 
 
             if (!everyFMUSupportsGetState && jacobianStepConfig.stabilisation) {
@@ -221,22 +223,12 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
             // Event Step 0: create time based clocks. We need to obtain the specific timing variables from
 //            fmuInstances3.values().stream().findFirst().get().
 
+
             // Event Init step 1: get clocks from others
-            for(var instance : fmuInstances3.values()) {
-                instance.enterEventMode();
-                var clockPorts =instance.getPorts().stream().filter(isClock).toList();
-                clockPorts.stream().filter(isCausalityOutput).forEach(p-> instance.getAndShare(p));
-            }
-
-            // Event update the initial event states not sure if we should set clocks before this
-
-
-
-
-            //we need to make sure every instance is ready for step mode
-            for(var instance : fmuInstances3.values()) {
-                instance.enterStepMode();
-            }
+            builder.getLogger().debug(blockMessage("Jaccobian Event handling before loop"));
+            builder.getLogger().debug("EVENT - Before step event handling");
+            var eventCapableInstances = fmuInstances3.values().stream().filter(hasEventMode).toList();
+            var eventUpdatingFlags = updateEventsInEventMode(builder, eventCapableInstances, fmuInstances3, ctxt);
 
             //TODO: OK now clocked variables must be filtered as they are only available in event mode
 
@@ -261,6 +253,7 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
             // Initialise swap and step condition variables
             ModelSwapBuilder.ModelSwapContext modelSwapContext = ModelSwapBuilder.buildContext(env, dynamicScope);
 
+            builder.getLogger().debug(blockMessage("Jaccobian main loop"));
             ScopeFmi2Api scopeFmi2Api = dynamicScope.enterWhile(loopPredicate);
             {
                 ScopeFmi2Api stoppingThenScope = scopeFmi2Api.enterIf(simulationControl.stopRequested().toPredicate()).enterThen();
@@ -292,7 +285,9 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
                 // SET ALL LINKED VARIABLES
                 // This has to be carried out regardless of stabilisation or not.
                 ModelSwapBuilder.setWithModelSwapLinking(fmuInstances, env, dynamicScope, modelSwapContext);
-                fmuInstances3.values().forEach( instance -> instance.setLinked(instance.getPorts().stream().filter(InstanceVariableFmi3Api.isLinked.and(isClockedVariable.negate()).and(isClock.negate())).toArray(PortFmi3Api[]::new)));
+                fmuInstances3.values().forEach(instance -> instance.setLinked(
+                        instance.getPorts().stream().filter(InstanceVariableFmi3Api.isLinked.and(isClockedVariable.negate()).and(isClock.negate()))
+                                .toArray(PortFmi3Api[]::new)));
 
                 if (algorithm == StepAlgorithm.VARIABLESTEP) {
                     // Get variable step
@@ -303,93 +298,16 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
                 anyDiscards.setValue(new BooleanVariableFmi2Api(null, null, dynamicScope, null, MableAstFactory.newABoolLiteralExp(false)));
 
                 // STEP ALL FMI2
-                fmuInstanceToCommunicationPoint.forEach((instance, communicationPoint) -> {
-
-                    DoubleVariableFmi2Api communicationTime = ctxt.currentCommunicationTime;
-
-                    Map.Entry<DoubleVariableFmi2Api, Optional<PredicateFmi2Api>> swapStep = ModelSwapBuilder.updateStep(modelSwapContext, env, instance,
-                            communicationTime);
-
-                    Optional<PredicateFmi2Api> stepPredicate = swapStep.getValue();
-                    communicationTime = swapStep.getKey();
-
-                    stepPredicate.ifPresent(dynamicScope::enterIf);
-
-                    Map.Entry<FmiBuilder.BoolVariable<PStm>, FmiBuilder.DoubleVariable<PStm>> discard = instance.step(communicationTime, ctxt.currentStepSize);
-
-                    communicationPoint.setValue(new DoubleExpressionValue(discard.getValue().getExp()));
-
-                    PredicateFmi2Api didDiscard = new PredicateFmi2Api(discard.getKey().getExp()).not();
-
-                    dynamicScope.enterIf(didDiscard);
-                    {
-                        builder.getLogger()
-                                .debug("## FMU: '%s' DISCARDED step at sim-time: %f for step-size: %f and proposed sim-time: %.15f", instance.getName(),
-                                        communicationTime, ctxt.currentStepSize,
-                                        new VariableFmi2Api<>(null, discard.getValue().getType(), dynamicScope, dynamicScope, null,
-                                                discard.getValue().getExp()));
-                        anyDiscards.setValue(new BooleanVariableFmi2Api(null, null, dynamicScope, null, anyDiscards.toPredicate().or(didDiscard).getExp()));
-                        dynamicScope.leave();
-                    }
-
-                    if (stepPredicate.isPresent()) {
-                        dynamicScope.leave();
-                    }
-                });
+                stepAllFmi2(builder, fmuInstanceToCommunicationPoint, ctxt, modelSwapContext, env, dynamicScope, anyDiscards);
 
                 // STEP ALL FMI3
-                fmuInstance3ToCommunicationPoint.forEach((instance, communicationPoint) -> {
-
-                    DoubleVariableFmi2Api communicationTime = ctxt.currentCommunicationTime;
-
-//                    Map.Entry<DoubleVariableFmi2Api, Optional<PredicateFmi2Api>> swapStep = ModelSwapBuilder.updateStep(modelSwapContext, env, instance,
-//                            communicationTime);
-
-//                    Optional<PredicateFmi2Api> stepPredicate = swapStep.getValue();
-//                    communicationTime = swapStep.getKey();
-
-//                    stepPredicate.ifPresent(dynamicScope::enterIf);
-
-                    var discard = instance.step(builder.getDynamicScope(),
-                            communicationTime, ctxt.currentStepSize, new ABoolLiteralExp(new LexLocation("",0,0),false));
-
-                    communicationPoint.setValue(new DoubleExpressionValue(discard.getValue().getLastSuccessfulTime().getExp()));
-
-                    PredicateFmi2Api didDiscard = new PredicateFmi2Api(discard.getKey().getExp()).not();
-
-                    dynamicScope.enterIf(didDiscard);
-                    {
-                        builder.getLogger()
-                                .debug("## FMU: '%s' DISCARDED step at sim-time: %f for step-size: %f and proposed sim-time: %.15f", instance.getName(),
-                                        communicationTime, ctxt.currentStepSize,
-                                        new VariableFmi2Api<>(null, discard.getValue().getLastSuccessfulTime().getType(), dynamicScope, dynamicScope, null,
-                                                discard.getValue().getLastSuccessfulTime().getExp()));
-                        anyDiscards.setValue(new BooleanVariableFmi2Api(null, null, dynamicScope, null, anyDiscards.toPredicate().or(didDiscard).getExp()));
-                        dynamicScope.leave();
-                    }
-
-//                    if (stepPredicate.isPresent()) {
-//                        dynamicScope.leave();
-//                    }
-                });
+                /**
+                 * FMI 3 step mode stepping
+                 * */
+                stepAllFmi3(builder, fmuInstance3ToCommunicationPoint, ctxt, fmuInstances3, eventUpdatingFlags, dynamicScope, anyDiscards);
 
                 // GET ALL LINKED OUTPUTS INCLUDING LOGGING OUTPUTS
-                for (var entry : componentsToPortsWithValues.entrySet()) {
-                    var portsToValues = entry.getValue();
-                    portsToValues = entry.getKey().get(portsToValues.keySet().toArray(PortFmi2Api[]::new));
-                }
-                for (var entry : instancesToPortsWithValues.entrySet()) {
-                    var portsToValues = entry.getValue();
-
-                    InstanceVariableFmi3Api instance = entry.getKey();
-
-                    for (PortFmi3Api p : portsToValues.keySet().stream().filter(isClockedVariable.negate()).toArray(PortFmi3Api[]::new)) {
-                        var val = instance.get(p);
-                        instance.share(val);
-                    }
-
-//                    portsToValues = entry.getKey().get(portsToValues.keySet().toArray(PortFmi3Api[]::new));
-                }
+                getStepOutputs(componentsToPortsWithValues, instancesToPortsWithValues);
 
                 // CONVERGENCE
                 if (jacobianStepConfig.stabilisation) {
@@ -445,7 +363,16 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
 
                     // Log values at current communication point
                     dataWriterInstance.log(ctxt.currentCommunicationTime);
-                    ctxt.currentStepSize.setValue(ctxt.stepSize);
+                    eventUpdatingFlags = updateEventsInEventMode(builder, eventCapableInstances, fmuInstances3, ctxt);
+
+
+                    ctxt.currentStepSize.setValue(calculateNextStepSize(builder, ctxt, timeBasedInputClockPorts));
+                    var checkStepSizeScope = builder.getDynamicScope().enterIf(ctxt.currentStepSize.toMath().lessEqualTo(IntExpressionValue.of(0)));
+                    var checkStepSizeScopeThen = checkStepSizeScope.enterThen();
+                    builder.getLogger().debug("Step size must be positive: %f", ctxt.currentStepSize);
+//                    checkStepSizeScopeThen.add(new AErrorStm(newAStringLiteralExp("Step size must be positive")));
+                    checkStepSizeScope.leave();
+                    builder.getLogger().debug("## Step size: %f", ctxt.currentStepSize);
                 }
 
                 scopeFmi2Api.leave();
@@ -464,6 +391,279 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
         }
 
         return new EmptyRuntimeConfig<>();
+    }
+
+    private static DoubleVariableFmi2Api calculateNextStepSize(MablApiBuilder builder, JacobianInternalBuilder.Jacobian3Context ctxt,
+                                                               Map<InstanceVariableFmi3Api, Stream<PortFmi3Api>> timeBasedInputClockPorts) {
+        if (timeBasedInputClockPorts.isEmpty()) {
+
+            return ctxt.stepSize;
+        }
+
+
+        // preconfigure the step size to the shift only if we have clocks
+        int clockIndex = 1;
+        ctxt.stepSizes.items().getFirst().setValue(ctxt.stepSize);
+        builder.getLogger().debug("## StepSizes[0]: %s", ctxt.stepSizes.items().get(0));
+        for (var instance : ctxt.fmu3Instances.entrySet()) {
+            var clockTimePorts = instance.getValue().getPorts().stream().filter(isClockTimeBased).toList();
+            for (var clockPort : clockTimePorts) {
+                var stepSizeVar = ctxt.stepSizes.items().get(clockIndex++);
+
+                //ok so we need step size from now and we need to consider if it ever ticked
+                InstanceClocksFmi3 clocks = instance.getValue().getClocksUtil();
+
+                stepSizeVar.setValue(clocks.getTimeToTick(ctxt.currentCommunicationTime.toMath(), clockPort));
+                builder.getLogger().debug("## StepSizes["+(clockIndex-1)+"]: %s", stepSizeVar);
+            }
+        }
+        builder.getLogger().debug("## current time: %s", ctxt.currentCommunicationTime);
+        return builder.getMathBuilder().minRealFromArray(ctxt.stepSizes);
+
+
+    }
+
+    @NotNull
+    private static Map<String, BooleanVariableFmi2Api> updateEventsInEventMode(MablApiBuilder builder,
+                                                                               List<InstanceVariableFmi3Api> eventCapableInstances,
+                                                                               Map<String, InstanceVariableFmi3Api> fmuInstances3,
+                                                                               JacobianInternalBuilder.Jacobian3Context ctxt) {
+        eventCapableInstances.forEach(InstanceVariableFmi3Api::enterEventMode);
+        var eventUpdatingFlags = fmuInstances3.entrySet().stream().filter(map -> hasEventMode.test(map.getValue()))
+                .collect(Collectors.toMap(Map.Entry::getKey, map -> builder.getDynamicScope().store(map.getKey() + "ProcessEvents", true)));
+        builder.getLogger().debug("EVENT - Get and Share clocks");
+//            for (var instance : eventCapableInstances) {
+//                var clockPorts = instance.getPorts().stream().filter(isClock).toList();
+//                // initial get all output clocks
+//                clockPorts.stream().filter(isCausalityOutput.and(isClockTriggered)).forEach(instance::getAndShare);
+//            }
+
+
+        //TODO we also need all the clocked variables that are not continuous
+
+                /* now we need to handle the events. That is:
+                     - set clocks
+                     - set clock dependent none continuous scalar variables
+                     - FMI3UpdateDiscreteStates until no updates are needed
+                 */
+
+
+        processEvents(builder, eventCapableInstances, ctxt, eventUpdatingFlags, fmuInstances3);
+
+
+        //we need to make sure every instance is ready for step mode
+        eventCapableInstances.forEach(InstanceVariableFmi3Api::enterStepMode);
+        return eventUpdatingFlags;
+    }
+
+    private static void processEvents(MablApiBuilder builder, List<InstanceVariableFmi3Api> eventCapableInstances,
+                                      JacobianInternalBuilder.Jacobian3Context ctxt,
+                                      Map<String, BooleanVariableFmi2Api> eventUpdatingFlags, Map<String, InstanceVariableFmi3Api> fmuInstances3) {
+        var eventHandlingScope = builder.getDynamicScope().enterScope();
+
+        updateTriggeredClocks(eventCapableInstances);
+        updateTimeBasedClocks(builder, eventCapableInstances, ctxt);
+
+        updateEventStates(builder, eventUpdatingFlags, fmuInstances3, ctxt);
+
+
+        // Event update the initial event states not sure if we should set clocks before this
+        // set shared clocks
+        // set time based clocks that are not shifted yes
+        //FMI3UpdateDiscreteStates
+
+        eventHandlingScope.leave();
+    }
+
+    private static void updateTriggeredClocks(List<InstanceVariableFmi3Api> eventCapableInstances) {
+        //get all triggered output clocks and make them available
+        //noinspection unchecked
+        eventCapableInstances.forEach(
+                instance -> instance.getPorts().stream().filter(isClock).filter(isCausalityOutput.and(isClockTriggered)).forEach(instance::getAndShare));
+        //set all triggered input clocks
+        eventCapableInstances.forEach(
+                instance -> instance.getPorts().stream().filter(isClock).filter(isCausalityInput.and(isClockTriggered)).forEach(instance::setLinked));
+        //if a clock is triggered then we need to obtain all variables related to it and share them
+        //TODO if a clock is triggered then we need to obtain all variables related to it and share them
+
+    }
+
+    private static void stepAllFmi2(MablApiBuilder builder, Map<ComponentVariableFmi2Api, VariableFmi2Api<Double>> fmuInstanceToCommunicationPoint,
+                                    JacobianInternalBuilder.Jacobian3Context ctxt, ModelSwapBuilder.ModelSwapContext modelSwapContext,
+                                    Fmi2SimulationEnvironment env, DynamicActiveBuilderScope dynamicScope, BooleanVariableFmi2Api anyDiscards) {
+        fmuInstanceToCommunicationPoint.forEach((instance, communicationPoint) -> {
+
+            DoubleVariableFmi2Api communicationTime = ctxt.currentCommunicationTime;
+
+            Map.Entry<DoubleVariableFmi2Api, Optional<PredicateFmi2Api>> swapStep = ModelSwapBuilder.updateStep(modelSwapContext, env, instance,
+                    communicationTime);
+
+            Optional<PredicateFmi2Api> stepPredicate = swapStep.getValue();
+            communicationTime = swapStep.getKey();
+
+            stepPredicate.ifPresent(dynamicScope::enterIf);
+
+            Map.Entry<FmiBuilder.BoolVariable<PStm>, FmiBuilder.DoubleVariable<PStm>> discard = instance.step(communicationTime,
+                    ctxt.currentStepSize);
+
+            communicationPoint.setValue(new DoubleExpressionValue(discard.getValue().getExp()));
+
+            PredicateFmi2Api didDiscard = new PredicateFmi2Api(discard.getKey().getExp()).not();
+
+            dynamicScope.enterIf(didDiscard);
+            {
+                builder.getLogger()
+                        .debug("## FMU: '%s' DISCARDED step at sim-time: %f for step-size: %f and proposed sim-time: %.15f", instance.getName(),
+                                communicationTime, ctxt.currentStepSize,
+                                new VariableFmi2Api<>(null, discard.getValue().getType(), dynamicScope, dynamicScope, null,
+                                        discard.getValue().getExp()));
+                anyDiscards.setValue(new BooleanVariableFmi2Api(null, null, dynamicScope, null, anyDiscards.toPredicate().or(didDiscard).getExp()));
+                dynamicScope.leave();
+            }
+
+            if (stepPredicate.isPresent()) {
+                dynamicScope.leave();
+            }
+        });
+    }
+
+    private static void stepAllFmi3(MablApiBuilder builder, Map<InstanceVariableFmi3Api, VariableFmi2Api<Double>> fmuInstance3ToCommunicationPoint,
+                                    JacobianInternalBuilder.Jacobian3Context ctxt, Map<String, InstanceVariableFmi3Api> fmuInstances3,
+                                    Map<String, BooleanVariableFmi2Api> eventUpdatingFlags, DynamicActiveBuilderScope dynamicScope,
+                                    BooleanVariableFmi2Api anyDiscards) {
+        fmuInstance3ToCommunicationPoint.forEach((instance, communicationPoint) -> {
+
+            DoubleVariableFmi2Api communicationTime = ctxt.currentCommunicationTime;
+
+//                    Map.Entry<DoubleVariableFmi2Api, Optional<PredicateFmi2Api>> swapStep = ModelSwapBuilder.updateStep(modelSwapContext, env, instance,
+//                            communicationTime);
+
+//                    Optional<PredicateFmi2Api> stepPredicate = swapStep.getValue();
+//                    communicationTime = swapStep.getKey();
+
+//                    stepPredicate.ifPresent(dynamicScope::enterIf);
+
+            var requireEventProcessing = fmuInstances3.entrySet().stream().filter(map -> map.getValue().equals(instance)).map(Map.Entry::getKey).map(
+                    eventUpdatingFlags::get).findFirst().orElse(null);
+            ABoolLiteralExp noSetFMUStatePriorToCurrentPoint = new ABoolLiteralExp(new LexLocation("", 0, 0), false);
+            var stepResult = instance.step(builder.getDynamicScope(),
+                    communicationTime, ctxt.currentStepSize,
+                    noSetFMUStatePriorToCurrentPoint, new InstanceVariableFmi3Api.StepResult(requireEventProcessing, null, null, null));
+
+            var stepReturnData = stepResult.getValue();
+
+            communicationPoint.setValue(new DoubleExpressionValue(stepReturnData.getLastSuccessfulTime().getExp()));
+
+            PredicateFmi2Api didDiscard = new PredicateFmi2Api(stepResult.getKey().getExp()).not();
+
+            dynamicScope.enterIf(didDiscard);
+            {
+                builder.getLogger()
+                        .debug("## FMU: '%s' DISCARDED step at sim-time: %f for step-size: %f and proposed sim-time: %.15f", instance.getName(),
+                                communicationTime, ctxt.currentStepSize,
+                                new VariableFmi2Api<>(null, stepReturnData.getLastSuccessfulTime().getType(), dynamicScope, dynamicScope, null,
+                                        stepReturnData.getLastSuccessfulTime().getExp()));
+                anyDiscards.setValue(new BooleanVariableFmi2Api(null, null, dynamicScope, null, anyDiscards.toPredicate().or(didDiscard).getExp()));
+                dynamicScope.leave();
+            }
+
+//                    if (stepPredicate.isPresent()) {
+//                        dynamicScope.leave();
+//                    }
+        });
+    }
+
+    private static void getStepOutputs(Map<ComponentVariableFmi2Api, Map<PortFmi2Api, VariableFmi2Api<Object>>> componentsToPortsWithValues,
+                                       Map<InstanceVariableFmi3Api, Map<PortFmi3Api, VariableFmi2Api<Object>>> instancesToPortsWithValues) {
+        for (var entry : componentsToPortsWithValues.entrySet()) {
+            var portsToValues = entry.getValue();
+            portsToValues = entry.getKey().get(portsToValues.keySet().toArray(PortFmi2Api[]::new));
+        }
+        for (var entry : instancesToPortsWithValues.entrySet()) {
+            var portsToValues = entry.getValue();
+
+            InstanceVariableFmi3Api instance = entry.getKey();
+
+            for (PortFmi3Api p : portsToValues.keySet().stream().filter(isClockedVariable.negate()).toArray(PortFmi3Api[]::new)) {
+                var val = instance.get(p);
+                instance.share(val);
+            }
+
+//                    portsToValues = entry.getKey().get(portsToValues.keySet().toArray(PortFmi3Api[]::new));
+        }
+    }
+
+    private static void updateEventStates(MablApiBuilder builder, Map<String, BooleanVariableFmi2Api> eventUpdatingFlags,
+                                          Map<String, InstanceVariableFmi3Api> fmuInstances3, JacobianInternalBuilder.Jacobian3Context ctxt) {
+        var dontCareBool = builder.getDynamicScope().store("dont_care_bool", false);
+        var dontCareReal = builder.getDynamicScope().store("dont_care_real", 0.0);
+
+        // keep looping while any of needs an update
+        builder.getDynamicScope()
+                .enterWhile(eventUpdatingFlags.values().stream().map(BooleanVariableFmi2Api::toPredicate).reduce(PredicateFmi2Api::or).orElse(null));
+
+        for (var entry : eventUpdatingFlags.entrySet()) {
+            var k = entry.getKey();
+            var processEvents = entry.getValue();
+            var instance = fmuInstances3.get(k);
+            var processEventsScope = builder.getDynamicScope().enterIf(processEvents.toPredicate());
+
+            instance.updateDiscreteStates(builder.getDynamicScope(), processEvents, ctxt.terminateSimulation, dontCareBool, dontCareBool, dontCareBool,
+                    dontCareReal);
+
+            var ifNeedsProcessing = builder.getDynamicScope().enterIf(processEvents.toPredicate());
+            builder.getLogger().info("## FMU: " + instance.getName() + " EVENTS UPDATED");
+            ifNeedsProcessing.leave();
+            //TODO check for terminate simulation
+
+            processEventsScope.leave();
+        }
+    }
+
+    private static void updateTimeBasedClocks(MablApiBuilder builder, List<InstanceVariableFmi3Api> eventCapableInstances,
+                                              JacobianInternalBuilder.Jacobian3Context ctxt) {
+        for (var instance : eventCapableInstances) {
+            var clockPorts = instance.getPorts().stream().filter(isClock).toList();
+
+
+            //we do this in two stages triggered and times
+//                instance.setLinked(clockPorts.stream().filter(isCausalityInput.and(isClockTriggered)).map(PortFmi3Api::getName).toArray(String[]::new));
+
+
+            var timeBasedClockPorts = clockPorts.stream().filter(isCausalityInput.and(isClockTimeBased)).toList();
+            if (timeBasedClockPorts.isEmpty()) {
+                continue;
+            }
+            builder.getLogger().debug("Processing clock (time-based clocks) for " + instance.getName());
+            timeBasedClockPorts.forEach(clockPort -> {
+
+                var ifScope = builder.getDynamicScope()
+                        .enterIf(instance.getClocksUtil().check(builder.getDynamicScope(), ctxt.currentCommunicationTime.toMath(), clockPort));
+                builder.getLogger().debug("\tTimed clock of %s.%s TRIGGERED".formatted(instance.getName(), clockPort.getName()));
+                instance.set(clockPort, BooleanExpressionValue.of(true));
+                builder.getDynamicScope().add(new ADebugStm(Collections.singletonList(new AStringLiteralExp(null,"context"))));
+                ifScope.leave();
+
+            });
+
+        }
+    }
+
+    private static boolean isEveryFMUSupportsGetState
+            (Map<String, ComponentVariableFmi2Api> fmuInstances, Map<String, InstanceVariableFmi3Api> fmuInstances3) {
+        return fmuInstances.values().stream().allMatch(inst -> {
+            try {
+                return inst.getModelDescription().getCanGetAndSetFmustate();
+            } catch (XPathExpressionException e) {
+                throw new RuntimeException(e);
+            }
+        }) && fmuInstances3.values().stream().allMatch(inst -> {
+            try {
+                return inst.getModelDescription().getCanGetAndSetFmustate();
+            } catch (XPathExpressionException e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
 

--- a/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/JacobianStepBuilder3.java
+++ b/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/JacobianStepBuilder3.java
@@ -54,347 +54,6 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
         imports.add("FMI3");
     }
 
-
-    @Override
-    protected List<IndexedFunctionDeclarationContainer<ARG_INDEX>> getFunctions() {
-        return Collections.singletonList(fixedStep3Func);
-    }
-
-    private String blockMessage(String msg) {
-        String seperator = "#############################################";
-        return seperator + "## " + msg + " " + seperator;
-    }
-
-    @Override
-    public <R> RuntimeConfigAddition<R> expandWithRuntimeAddition(AFunctionDeclaration declaredFunction,
-                                                                  FmiBuilder<PStm, ASimulationSpecificationCompilationUnit, PExp, ?> parentBuilder,
-                                                                  List<FmiBuilder.Variable<PStm, ?>> formalArguments, IPluginConfiguration config,
-                                                                  ISimulationEnvironment envIn, IErrorReporter errorReporter) throws ExpandException {
-
-
-        logger.info("Unfolding with jacobian step: {}", declaredFunction.toString());
-        JacobianStepConfig jacobianStepConfig = config != null ? (JacobianStepConfig) config : new JacobianStepConfig();
-
-        if (!getDeclaredUnfoldFunctions().contains(declaredFunction)) {
-            throw new ExpandException("Unknown function declaration");
-        }
-
-        if (envIn == null) {
-            throw new ExpandException("Simulation environment must not be null");
-        }
-
-        IndexedFunctionDeclarationContainer<ARG_INDEX> selectedFun = getFunctions().stream()
-                .filter(f -> f.getDecl().getName().getText().equals(declaredFunction.getName().getText())).findFirst().orElse(null);
-
-        StepAlgorithm algorithm = StepAlgorithm.FIXEDSTEP;
-
-
-        if (selectedFun == variableStepFunc) {
-            algorithm = StepAlgorithm.VARIABLESTEP;
-            imports.add("VariableStep");
-        } else if (selectedFun == fixedStepTransferFunc) {
-            algorithm = StepAlgorithm.FIXEDSTEP;
-            logger.debug("Activated mode transfer");
-        }
-
-        if (formalArguments == null || formalArguments.size() != selectedFun.getDecl().getFormals().size()) {
-            throw new ExpandException("Invalid args");
-        }
-
-
-        Fmi2SimulationEnvironment env = (Fmi2SimulationEnvironment) envIn;
-
-        boolean setGetDerivativesRestore = false;
-        MablApiBuilder.MablSettings settings = null;
-        try {
-            if (parentBuilder.getSettings() instanceof MablApiBuilder.MablSettings) {
-                //FIXME we should probably not do this in a plugin as it changes this for all once the builder is reused!
-                settings = (MablApiBuilder.MablSettings) parentBuilder.getSettings();
-                setGetDerivativesRestore = settings.setGetDerivatives;
-                settings.setGetDerivatives = jacobianStepConfig.setGetDerivatives;
-            }
-
-            if (!(parentBuilder instanceof MablApiBuilder builder)) {
-                throw new ExpandException(
-                        "Not supporting the given builder type. Expecting " + MablApiBuilder.class.getSimpleName() + " got " + parentBuilder.getClass()
-                                .getSimpleName());
-            }
-
-            DynamicActiveBuilderScope dynamicScope = builder.getDynamicScope();
-            MathBuilderFmi2Api math = builder.getMablToMablAPI().getMathBuilder();
-            BooleanBuilderFmi2Api booleanLogic = builder.getBooleanBuilder();
-
-            RealTimeSlowDownBuilder.RealTimeSlowDownContext ctsCtxt = null;
-            if (jacobianStepConfig.simulationProgramDelay) {
-                ctsCtxt = RealTimeSlowDownBuilder.init(builder, imports);
-            }
-
-            // Convert raw MaBL to API
-            var ctxt = JacobianInternalBuilder.buildBaseFmi3Ctxt(builder, selectedFun, formalArguments, dynamicScope);
-
-            var fmuInstances = ctxt.fmuInstances;
-            var fmuInstances3 = ctxt.fmu3Instances;
-
-            var timeBasedInputClockPorts = fmuInstances3.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue,
-                    m -> m.getValue().getPorts().stream().filter(isClock).filter(isCausalityInput.and(isClockTimeBased))));
-
-
-            // Create the logging
-            DataWriter dataWriter = builder.getDataWriter();
-            DataWriter.DataWriterInstance dataWriterInstance = dataWriter.createDataWriterInstance();
-            List<DataWriter.DataWriterInstance.LogEntry> logVariables = Stream.concat(fmuInstances.values().stream().flatMap(x -> x.getVariablesToLog().stream()
-                    .map(xsv -> new DataWriter.DataWriterInstance.LogEntry(xsv.getMultiModelScalarVariableName(),
-                            () -> xsv.getSharedAsVariable().getReferenceExp().clone()))), fmuInstances3.values().stream().flatMap(
-                    x -> x.getVariablesToLog().stream().map(xsv -> new DataWriter.DataWriterInstance.LogEntry(xsv.getMultiModelScalarVariableName(),
-                            () -> xsv.getSharedAsVariable().getReferenceExp().clone())))
-
-            ).collect(Collectors.toList());
-            var timeBasedClocksLogVariables = timeBasedInputClockPorts.entrySet().stream().flatMap(m -> m.getValue()
-                    .map(clockPort -> new DataWriter.DataWriterInstance.LogEntry(clockPort.getMultiModelScalarVariableName(),
-                            () -> m.getKey().getClocksUtil().getClockTriggeredState(clockPort).getReferenceExp().clone()))).toList();
-            logVariables.addAll(timeBasedClocksLogVariables);
-            logVariables.addFirst(new DataWriter.DataWriterInstance.LogEntry("eventMode", () -> ctxt.eventMode.getReferenceExp().clone()));
-            dataWriterInstance.initialize(logVariables);
-
-            // Create simulation control to allow for user interactive loop stopping
-            SimulationControl simulationControl = builder.getSimulationControl();
-
-            // Create the iteration predicate
-            PredicateFmi2Api loopPredicate = ctxt.externalEndTimeDefined.toPredicate().not()
-                    .or(ctxt.currentCommunicationTime.toMath().addition(ctxt.currentStepSize).lessThan(ctxt.endTime));
-
-
-            // Get all variables related to outputs or logging.
-            Map<ComponentVariableFmi2Api, Map<PortFmi2Api, VariableFmi2Api<Object>>> componentsToPortsWithValues = JacobianVariableStepBuilder.getAllComponentPortsWithOutputOrLog(
-                    fmuInstances, jacobianStepConfig, env);
-
-            Map<InstanceVariableFmi3Api, Map<PortFmi3Api, VariableFmi2Api<Object>>> instancesToPortsWithValues = JacobianVariableStepBuilder.getAllInstancePortsWithOutputOrLog(
-                    fmuInstances3, jacobianStepConfig, env);
-
-            builder.getLogger().debug(blockMessage("Jaccobian start"));
-
-            // Share
-            componentsToPortsWithValues.forEach(ComponentVariableFmi2Api::share);
-            instancesToPortsWithValues.forEach(InstanceVariableFmi3Api::share);
-
-            // Build static FMU relations
-            Map<StringVariableFmi2Api, ComponentVariableFmi2Api> fmuNamesToFmuInstances = new LinkedHashMap<>();
-
-            ArrayVariableFmi2Api<Double> fmuCommunicationPoints = dynamicScope.store("fmu_communicationpoints",
-                    new Double[fmuInstances.size() + fmuInstances3.size()]);
-
-            for (ComponentVariableFmi2Api instance : fmuInstances.values()) {
-
-                FrameworkUnitInfo v = env.getInstanceByLexName(instance.getEnvironmentName());
-                if (v instanceof ComponentInfo) {
-                    StringVariableFmi2Api fullyQualifiedFMUInstanceName = new StringVariableFmi2Api(null, null, null, null,
-                            MableAstFactory.newAStringLiteralExp(((ComponentInfo) v).getFmuIdentifier() + "." + instance.getName()));
-                    fmuNamesToFmuInstances.put(fullyQualifiedFMUInstanceName, instance);
-                } else {
-                    throw new RuntimeException("instance is not fmi2");
-                }
-
-
-            }
-
-            AtomicInteger indexer = new AtomicInteger();
-            var fmuInstanceToCommunicationPoint = fmuInstances.values().stream()
-                    .collect(Collectors.toMap(inst -> inst, instance -> fmuCommunicationPoints.items().get(indexer.getAndIncrement())));
-
-            var fmuInstance3ToCommunicationPoint = fmuInstances3.values().stream()
-                    .collect(Collectors.toMap(inst -> inst, instance -> fmuCommunicationPoints.items().get(indexer.getAndIncrement())));
-
-
-            // validate if all fmus can get state
-            boolean everyFMUSupportsGetState = isEveryFMUSupportsGetState(fmuInstances, fmuInstances3);
-
-
-            if (!everyFMUSupportsGetState && jacobianStepConfig.stabilisation) {
-                throw new RuntimeException("Cannot use stabilisation as not every FMU supports rollback");
-            }
-
-            BooleanVariableFmi2Api allFMUsSupportGetState = dynamicScope.store("all_fmus_support_get_state", everyFMUSupportsGetState);
-
-            JacobianVariableStepBuilder.JacobianVariableStepContext varStep = null;
-            if (algorithm == StepAlgorithm.VARIABLESTEP) {
-                varStep = JacobianVariableStepBuilder.init(ctxt, jacobianStepConfig, dynamicScope, builder, fmuNamesToFmuInstances);
-            }
-
-            // TODO: we need to handle the initial event loop for clocks
-
-            // Event Step 0: create time based clocks. We need to obtain the specific timing variables from
-//            fmuInstances3.values().stream().findFirst().get().
-
-
-            // Event Init step 1: get clocks from others
-            builder.getLogger().debug(blockMessage("Jaccobian Event handling before loop"));
-            builder.getLogger().debug("EVENT - Before step event handling");
-            var eventCapableInstances = fmuInstances3.values().stream().filter(hasEventMode).toList();
-            var eventUpdatingFlags = updateEventsInEventMode(builder, eventCapableInstances, fmuInstances3, dataWriterInstance, ctxt);
-
-            //TODO: OK now clocked variables must be filtered as they are only available in event mode
-
-            // Log values at t = start time
-            dataWriterInstance.log(ctxt.currentCommunicationTime);
-
-
-            StabilisationBuilder.StabilisationContext stabilisationCtxt = null;
-            if (jacobianStepConfig.stabilisation) {
-                stabilisationCtxt = StabilisationBuilder.init(dynamicScope, jacobianStepConfig);
-            }
-
-
-            if (jacobianStepConfig.simulationProgramDelay) {
-                RealTimeSlowDownBuilder.setStartTime(ctsCtxt, dynamicScope);
-
-            }
-
-            List<FmiBuilder.StateVariable<PStm>> fmuStates = new ArrayList<>();
-            BooleanVariableFmi2Api anyDiscards = dynamicScope.store("any_discards", false);
-
-            // Initialise swap and step condition variables
-            ModelSwapBuilder.ModelSwapContext modelSwapContext = ModelSwapBuilder.buildContext(env, dynamicScope);
-
-            builder.getLogger().debug(blockMessage("Jaccobian main loop"));
-            ScopeFmi2Api scopeFmi2Api = dynamicScope.enterWhile(loopPredicate);
-            {
-                ScopeFmi2Api stoppingThenScope = scopeFmi2Api.enterIf(simulationControl.stopRequested().toPredicate()).enterThen();
-                stoppingThenScope.add(new AErrorStm(newAStringLiteralExp("Simulation stopped by user")));
-                stoppingThenScope.leave();
-
-                //mark a safe point for a transfer to another specification
-                dynamicScope.markTransferPoint();
-
-
-                // Update all swap and step condition variables
-                ModelSwapBuilder.updateSwapConditionVariables(modelSwapContext, dynamicScope, componentsToPortsWithValues);
-
-                // Get fmu states
-                if (everyFMUSupportsGetState) {
-                    for (ComponentVariableFmi2Api instance : fmuInstances.values()) {
-                        fmuStates.add(instance.getState());
-                    }
-                    for (InstanceVariableFmi3Api instance : fmuInstances3.values()) {
-                        fmuStates.add(instance.getState());
-                    }
-                }
-
-                if (jacobianStepConfig.stabilisation) {
-                    StabilisationBuilder.step(stabilisationCtxt, dynamicScope);
-
-                }
-
-                // SET ALL LINKED VARIABLES
-                // This has to be carried out regardless of stabilisation or not.
-                ModelSwapBuilder.setWithModelSwapLinking(fmuInstances, env, dynamicScope, modelSwapContext);
-                fmuInstances3.values().forEach(instance -> instance.setLinked(
-                        instance.getPorts().stream().filter(InstanceVariableFmi3Api.isLinked.and(isClockedVariable.negate()).and(isClock.negate()))
-                                .toArray(PortFmi3Api[]::new)));
-
-                if (algorithm == StepAlgorithm.VARIABLESTEP) {
-                    // Get variable step
-                    JacobianVariableStepBuilder.updateCurrentStepTiming(ctxt, varStep, dynamicScope, anyDiscards);
-
-                }
-
-                anyDiscards.setValue(new BooleanVariableFmi2Api(null, null, dynamicScope, null, MableAstFactory.newABoolLiteralExp(false)));
-
-                // STEP ALL FMI2
-                stepAllFmi2(builder, fmuInstanceToCommunicationPoint, ctxt, modelSwapContext, env, dynamicScope, anyDiscards);
-
-                // STEP ALL FMI3
-                /**
-                 * FMI 3 step mode stepping
-                 * */
-                stepAllFmi3(builder, fmuInstance3ToCommunicationPoint, ctxt, fmuInstances3, eventUpdatingFlags, dynamicScope, anyDiscards);
-
-                // GET ALL LINKED OUTPUTS INCLUDING LOGGING OUTPUTS
-                getStepOutputs(componentsToPortsWithValues, instancesToPortsWithValues);
-
-                // CONVERGENCE
-                if (jacobianStepConfig.stabilisation) {
-                    // CONVERGENCE
-                    StabilisationBuilder.convergence(dynamicScope, componentsToPortsWithValues, stabilisationCtxt, ctxt, builder, math, booleanLogic,
-                            fmuStates);
-
-                } else {
-                    // NORMAL SHARE - VALUE EXCHANGE
-                    componentsToPortsWithValues.forEach(ComponentVariableFmi2Api::share);
-//                    instancesToPortsWithValues.forEach(InstanceVariableFmi3Api::share);
-                }
-
-                if (everyFMUSupportsGetState) {
-                    // Discard
-                    IfMaBlScope discardScope = dynamicScope.enterIf(anyDiscards.toPredicate());
-                    {
-                        // Rollback FMUs
-                        fmuStates.forEach(FmiBuilder.StateVariable::set);
-
-                        // Set step-size to lowest
-                        ctxt.currentStepSize.setValue(math.minRealFromArray(fmuCommunicationPoints).toMath().subtraction(ctxt.currentCommunicationTime));
-
-                        builder.getLogger().debug("## Discard occurred! FMUs are rolled back and step-size reduced to: %f", ctxt.currentStepSize);
-
-                        dynamicScope.leave();
-                    }
-
-                    discardScope.enterElse();
-                }
-                {
-                    if (algorithm == StepAlgorithm.VARIABLESTEP) {
-                        // Validate step
-                        JacobianVariableStepBuilder.step(ctxt, varStep, dynamicScope, builder, allFMUsSupportGetState, fmuStates, anyDiscards);
-                    }
-
-                    // Slow-down to real-time
-                    if (jacobianStepConfig.simulationProgramDelay) {
-                        RealTimeSlowDownBuilder.slowDown(ctsCtxt, dynamicScope, ctxt, builder);
-                    }
-
-                    if (everyFMUSupportsGetState) {
-                        dynamicScope.leave();
-                    }
-                }
-
-                dynamicScope.enterIf(anyDiscards.toPredicate().not());
-                {
-                    // Update currentCommunicationTime
-                    ctxt.currentCommunicationTime.setValue(ctxt.currentCommunicationTime.toMath().addition(ctxt.currentStepSize));
-
-                    ModelSwapBuilder.updateDiscardStepTime(modelSwapContext, dynamicScope, ctxt.currentStepSize);
-
-                    // Log values at current communication point
-                    dataWriterInstance.log(ctxt.currentCommunicationTime);
-                    eventUpdatingFlags = updateEventsInEventMode(builder, eventCapableInstances, fmuInstances3, dataWriterInstance, ctxt);
-
-
-                    ctxt.currentStepSize.setValue(calculateNextStepSize(builder, ctxt, timeBasedInputClockPorts));
-                    var checkStepSizeScope = builder.getDynamicScope().enterIf(ctxt.currentStepSize.toMath().lessEqualTo(IntExpressionValue.of(0)));
-                    var checkStepSizeScopeThen = checkStepSizeScope.enterThen();
-                    builder.getLogger().debug("Step size must be positive: %f", ctxt.currentStepSize);
-//                    checkStepSizeScopeThen.add(new AErrorStm(newAStringLiteralExp("Step size must be positive")));
-                    checkStepSizeScope.leave();
-                    builder.getLogger().debug("## Step size: %f", ctxt.currentStepSize);
-                }
-
-                scopeFmi2Api.leave();
-            }
-
-            dataWriterInstance.close();
-
-            if (settings != null) {
-                //restore previous state
-                settings.setGetDerivatives = setGetDerivativesRestore;
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            errorReporter.report(0, e.toString(), null);
-            throw new ExpandException("Internal error: ", e);
-        }
-
-        return new EmptyRuntimeConfig<>();
-    }
-
     private static DoubleVariableFmi2Api calculateNextStepSize(MablApiBuilder builder, JacobianInternalBuilder.Jacobian3Context ctxt,
                                                                Map<InstanceVariableFmi3Api, Stream<PortFmi3Api>> timeBasedInputClockPorts) {
         if (timeBasedInputClockPorts.isEmpty()) {
@@ -430,8 +89,11 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
                                                                                List<InstanceVariableFmi3Api> eventCapableInstances,
                                                                                Map<String, InstanceVariableFmi3Api> fmuInstances3,
                                                                                DataWriter.DataWriterInstance dataWriterInstance,
-                                                                               JacobianInternalBuilder.Jacobian3Context ctxt) {
-        eventCapableInstances.forEach(InstanceVariableFmi3Api::enterEventMode);
+                                                                               JacobianInternalBuilder.Jacobian3Context ctxt, boolean firstCall) {
+        if (!firstCall) {
+            //all FMUs here have been created with eventModeUser and thus must be in event mode at initialization
+            eventCapableInstances.forEach(InstanceVariableFmi3Api::enterEventMode);
+        }
         ctxt.eventMode.setValue(BooleanExpressionValue.of(true));
         var eventUpdatingFlags = fmuInstances3.entrySet().stream().filter(map -> hasEventMode.test(map.getValue()))
                 .collect(Collectors.toMap(Map.Entry::getKey, map -> builder.getDynamicScope().store(map.getKey() + "ProcessEvents", true)));
@@ -714,6 +376,346 @@ public class JacobianStepBuilder3 extends JacobianStepBuilder {
                 throw new RuntimeException(e);
             }
         });
+    }
+
+    @Override
+    protected List<IndexedFunctionDeclarationContainer<ARG_INDEX>> getFunctions() {
+        return Collections.singletonList(fixedStep3Func);
+    }
+
+    private String blockMessage(String msg) {
+        String seperator = "#############################################";
+        return seperator + "## " + msg + " " + seperator;
+    }
+
+    @Override
+    public <R> RuntimeConfigAddition<R> expandWithRuntimeAddition(AFunctionDeclaration declaredFunction,
+                                                                  FmiBuilder<PStm, ASimulationSpecificationCompilationUnit, PExp, ?> parentBuilder,
+                                                                  List<FmiBuilder.Variable<PStm, ?>> formalArguments, IPluginConfiguration config,
+                                                                  ISimulationEnvironment envIn, IErrorReporter errorReporter) throws ExpandException {
+
+
+        logger.info("Unfolding with jacobian step: {}", declaredFunction.toString());
+        JacobianStepConfig jacobianStepConfig = config != null ? (JacobianStepConfig) config : new JacobianStepConfig();
+
+        if (!getDeclaredUnfoldFunctions().contains(declaredFunction)) {
+            throw new ExpandException("Unknown function declaration");
+        }
+
+        if (envIn == null) {
+            throw new ExpandException("Simulation environment must not be null");
+        }
+
+        IndexedFunctionDeclarationContainer<ARG_INDEX> selectedFun = getFunctions().stream()
+                .filter(f -> f.getDecl().getName().getText().equals(declaredFunction.getName().getText())).findFirst().orElse(null);
+
+        StepAlgorithm algorithm = StepAlgorithm.FIXEDSTEP;
+
+
+        if (selectedFun == variableStepFunc) {
+            algorithm = StepAlgorithm.VARIABLESTEP;
+            imports.add("VariableStep");
+        } else if (selectedFun == fixedStepTransferFunc) {
+            algorithm = StepAlgorithm.FIXEDSTEP;
+            logger.debug("Activated mode transfer");
+        }
+
+        if (formalArguments == null || formalArguments.size() != selectedFun.getDecl().getFormals().size()) {
+            throw new ExpandException("Invalid args");
+        }
+
+
+        Fmi2SimulationEnvironment env = (Fmi2SimulationEnvironment) envIn;
+
+        boolean setGetDerivativesRestore = false;
+        MablApiBuilder.MablSettings settings = null;
+        try {
+            if (parentBuilder.getSettings() instanceof MablApiBuilder.MablSettings) {
+                //FIXME we should probably not do this in a plugin as it changes this for all once the builder is reused!
+                settings = (MablApiBuilder.MablSettings) parentBuilder.getSettings();
+                setGetDerivativesRestore = settings.setGetDerivatives;
+                settings.setGetDerivatives = jacobianStepConfig.setGetDerivatives;
+            }
+
+            if (!(parentBuilder instanceof MablApiBuilder builder)) {
+                throw new ExpandException(
+                        "Not supporting the given builder type. Expecting " + MablApiBuilder.class.getSimpleName() + " got " + parentBuilder.getClass()
+                                .getSimpleName());
+            }
+
+            DynamicActiveBuilderScope dynamicScope = builder.getDynamicScope();
+            MathBuilderFmi2Api math = builder.getMablToMablAPI().getMathBuilder();
+            BooleanBuilderFmi2Api booleanLogic = builder.getBooleanBuilder();
+
+            RealTimeSlowDownBuilder.RealTimeSlowDownContext ctsCtxt = null;
+            if (jacobianStepConfig.simulationProgramDelay) {
+                ctsCtxt = RealTimeSlowDownBuilder.init(builder, imports);
+            }
+
+            // Convert raw MaBL to API
+            var ctxt = JacobianInternalBuilder.buildBaseFmi3Ctxt(builder, selectedFun, formalArguments, dynamicScope);
+
+            var fmuInstances = ctxt.fmuInstances;
+            var fmuInstances3 = ctxt.fmu3Instances;
+
+            var timeBasedInputClockPorts = fmuInstances3.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue,
+                    m -> m.getValue().getPorts().stream().filter(isClock).filter(isCausalityInput.and(isClockTimeBased))));
+
+
+            // Create the logging
+            DataWriter dataWriter = builder.getDataWriter();
+            DataWriter.DataWriterInstance dataWriterInstance = dataWriter.createDataWriterInstance();
+            List<DataWriter.DataWriterInstance.LogEntry> logVariables = Stream.concat(fmuInstances.values().stream().flatMap(x -> x.getVariablesToLog().stream()
+                    .map(xsv -> new DataWriter.DataWriterInstance.LogEntry(xsv.getMultiModelScalarVariableName(),
+                            () -> xsv.getSharedAsVariable().getReferenceExp().clone()))), fmuInstances3.values().stream().flatMap(
+                    x -> x.getVariablesToLog().stream().map(xsv -> new DataWriter.DataWriterInstance.LogEntry(xsv.getMultiModelScalarVariableName(),
+                            () -> xsv.getSharedAsVariable().getReferenceExp().clone())))
+
+            ).collect(Collectors.toList());
+            var timeBasedClocksLogVariables = timeBasedInputClockPorts.entrySet().stream().flatMap(m -> m.getValue()
+                    .map(clockPort -> new DataWriter.DataWriterInstance.LogEntry(clockPort.getMultiModelScalarVariableName(),
+                            () -> m.getKey().getClocksUtil().getClockTriggeredState(clockPort).getReferenceExp().clone()))).toList();
+            logVariables.addAll(timeBasedClocksLogVariables);
+            logVariables.addFirst(new DataWriter.DataWriterInstance.LogEntry("eventMode", () -> ctxt.eventMode.getReferenceExp().clone()));
+            dataWriterInstance.initialize(logVariables);
+
+            // Create simulation control to allow for user interactive loop stopping
+            SimulationControl simulationControl = builder.getSimulationControl();
+
+            // Create the iteration predicate
+            PredicateFmi2Api loopPredicate = ctxt.externalEndTimeDefined.toPredicate().not()
+                    .or(ctxt.currentCommunicationTime.toMath().addition(ctxt.currentStepSize).lessThan(ctxt.endTime));
+
+
+            // Get all variables related to outputs or logging.
+            Map<ComponentVariableFmi2Api, Map<PortFmi2Api, VariableFmi2Api<Object>>> componentsToPortsWithValues = JacobianVariableStepBuilder.getAllComponentPortsWithOutputOrLog(
+                    fmuInstances, jacobianStepConfig, env);
+
+            Map<InstanceVariableFmi3Api, Map<PortFmi3Api, VariableFmi2Api<Object>>> instancesToPortsWithValues = JacobianVariableStepBuilder.getAllInstancePortsWithOutputOrLog(
+                    fmuInstances3, jacobianStepConfig, env);
+
+            builder.getLogger().debug(blockMessage("Jaccobian start"));
+
+            // Share
+            componentsToPortsWithValues.forEach(ComponentVariableFmi2Api::share);
+            instancesToPortsWithValues.forEach(InstanceVariableFmi3Api::share);
+
+            // Build static FMU relations
+            Map<StringVariableFmi2Api, ComponentVariableFmi2Api> fmuNamesToFmuInstances = new LinkedHashMap<>();
+
+            ArrayVariableFmi2Api<Double> fmuCommunicationPoints = dynamicScope.store("fmu_communicationpoints",
+                    new Double[fmuInstances.size() + fmuInstances3.size()]);
+
+            for (ComponentVariableFmi2Api instance : fmuInstances.values()) {
+
+                FrameworkUnitInfo v = env.getInstanceByLexName(instance.getEnvironmentName());
+                if (v instanceof ComponentInfo) {
+                    StringVariableFmi2Api fullyQualifiedFMUInstanceName = new StringVariableFmi2Api(null, null, null, null,
+                            MableAstFactory.newAStringLiteralExp(((ComponentInfo) v).getFmuIdentifier() + "." + instance.getName()));
+                    fmuNamesToFmuInstances.put(fullyQualifiedFMUInstanceName, instance);
+                } else {
+                    throw new RuntimeException("instance is not fmi2");
+                }
+
+
+            }
+
+            AtomicInteger indexer = new AtomicInteger();
+            var fmuInstanceToCommunicationPoint = fmuInstances.values().stream()
+                    .collect(Collectors.toMap(inst -> inst, instance -> fmuCommunicationPoints.items().get(indexer.getAndIncrement())));
+
+            var fmuInstance3ToCommunicationPoint = fmuInstances3.values().stream()
+                    .collect(Collectors.toMap(inst -> inst, instance -> fmuCommunicationPoints.items().get(indexer.getAndIncrement())));
+
+
+            // validate if all fmus can get state
+            boolean everyFMUSupportsGetState = isEveryFMUSupportsGetState(fmuInstances, fmuInstances3);
+
+
+            if (!everyFMUSupportsGetState && jacobianStepConfig.stabilisation) {
+                throw new RuntimeException("Cannot use stabilisation as not every FMU supports rollback");
+            }
+
+            BooleanVariableFmi2Api allFMUsSupportGetState = dynamicScope.store("all_fmus_support_get_state", everyFMUSupportsGetState);
+
+            JacobianVariableStepBuilder.JacobianVariableStepContext varStep = null;
+            if (algorithm == StepAlgorithm.VARIABLESTEP) {
+                varStep = JacobianVariableStepBuilder.init(ctxt, jacobianStepConfig, dynamicScope, builder, fmuNamesToFmuInstances);
+            }
+
+            // TODO: we need to handle the initial event loop for clocks
+
+            // Event Step 0: create time based clocks. We need to obtain the specific timing variables from
+//            fmuInstances3.values().stream().findFirst().get().
+
+
+            // Event Init step 1: get clocks from others
+            builder.getLogger().debug(blockMessage("Jaccobian Event handling before loop"));
+            builder.getLogger().debug("EVENT - Before step event handling");
+            var eventCapableInstances = fmuInstances3.values().stream().filter(hasEventMode).toList();
+            var eventUpdatingFlags = updateEventsInEventMode(builder, eventCapableInstances, fmuInstances3, dataWriterInstance, ctxt, true);
+
+            //TODO: OK now clocked variables must be filtered as they are only available in event mode
+
+            // Log values at t = start time
+            dataWriterInstance.log(ctxt.currentCommunicationTime);
+
+
+            StabilisationBuilder.StabilisationContext stabilisationCtxt = null;
+            if (jacobianStepConfig.stabilisation) {
+                stabilisationCtxt = StabilisationBuilder.init(dynamicScope, jacobianStepConfig);
+            }
+
+
+            if (jacobianStepConfig.simulationProgramDelay) {
+                RealTimeSlowDownBuilder.setStartTime(ctsCtxt, dynamicScope);
+
+            }
+
+            List<FmiBuilder.StateVariable<PStm>> fmuStates = new ArrayList<>();
+            BooleanVariableFmi2Api anyDiscards = dynamicScope.store("any_discards", false);
+
+            // Initialise swap and step condition variables
+            ModelSwapBuilder.ModelSwapContext modelSwapContext = ModelSwapBuilder.buildContext(env, dynamicScope);
+
+            builder.getLogger().debug(blockMessage("Jaccobian main loop"));
+            ScopeFmi2Api scopeFmi2Api = dynamicScope.enterWhile(loopPredicate);
+            {
+                ScopeFmi2Api stoppingThenScope = scopeFmi2Api.enterIf(simulationControl.stopRequested().toPredicate()).enterThen();
+                stoppingThenScope.add(new AErrorStm(newAStringLiteralExp("Simulation stopped by user")));
+                stoppingThenScope.leave();
+
+                //mark a safe point for a transfer to another specification
+                dynamicScope.markTransferPoint();
+
+
+                // Update all swap and step condition variables
+                ModelSwapBuilder.updateSwapConditionVariables(modelSwapContext, dynamicScope, componentsToPortsWithValues);
+
+                // Get fmu states
+                if (everyFMUSupportsGetState) {
+                    for (ComponentVariableFmi2Api instance : fmuInstances.values()) {
+                        fmuStates.add(instance.getState());
+                    }
+                    for (InstanceVariableFmi3Api instance : fmuInstances3.values()) {
+                        fmuStates.add(instance.getState());
+                    }
+                }
+
+                if (jacobianStepConfig.stabilisation) {
+                    StabilisationBuilder.step(stabilisationCtxt, dynamicScope);
+
+                }
+
+                // SET ALL LINKED VARIABLES
+                // This has to be carried out regardless of stabilisation or not.
+                ModelSwapBuilder.setWithModelSwapLinking(fmuInstances, env, dynamicScope, modelSwapContext);
+                fmuInstances3.values().forEach(instance -> instance.setLinked(
+                        instance.getPorts().stream().filter(InstanceVariableFmi3Api.isLinked.and(isClockedVariable.negate()).and(isClock.negate()))
+                                .toArray(PortFmi3Api[]::new)));
+
+                if (algorithm == StepAlgorithm.VARIABLESTEP) {
+                    // Get variable step
+                    JacobianVariableStepBuilder.updateCurrentStepTiming(ctxt, varStep, dynamicScope, anyDiscards);
+
+                }
+
+                anyDiscards.setValue(new BooleanVariableFmi2Api(null, null, dynamicScope, null, MableAstFactory.newABoolLiteralExp(false)));
+
+                // STEP ALL FMI2
+                stepAllFmi2(builder, fmuInstanceToCommunicationPoint, ctxt, modelSwapContext, env, dynamicScope, anyDiscards);
+
+                // STEP ALL FMI3
+                /**
+                 * FMI 3 step mode stepping
+                 * */
+                stepAllFmi3(builder, fmuInstance3ToCommunicationPoint, ctxt, fmuInstances3, eventUpdatingFlags, dynamicScope, anyDiscards);
+
+                // GET ALL LINKED OUTPUTS INCLUDING LOGGING OUTPUTS
+                getStepOutputs(componentsToPortsWithValues, instancesToPortsWithValues);
+
+                // CONVERGENCE
+                if (jacobianStepConfig.stabilisation) {
+                    // CONVERGENCE
+                    StabilisationBuilder.convergence(dynamicScope, componentsToPortsWithValues, stabilisationCtxt, ctxt, builder, math, booleanLogic,
+                            fmuStates);
+
+                } else {
+                    // NORMAL SHARE - VALUE EXCHANGE
+                    componentsToPortsWithValues.forEach(ComponentVariableFmi2Api::share);
+//                    instancesToPortsWithValues.forEach(InstanceVariableFmi3Api::share);
+                }
+
+                if (everyFMUSupportsGetState) {
+                    // Discard
+                    IfMaBlScope discardScope = dynamicScope.enterIf(anyDiscards.toPredicate());
+                    {
+                        // Rollback FMUs
+                        fmuStates.forEach(FmiBuilder.StateVariable::set);
+
+                        // Set step-size to lowest
+                        ctxt.currentStepSize.setValue(math.minRealFromArray(fmuCommunicationPoints).toMath().subtraction(ctxt.currentCommunicationTime));
+
+                        builder.getLogger().debug("## Discard occurred! FMUs are rolled back and step-size reduced to: %f", ctxt.currentStepSize);
+
+                        dynamicScope.leave();
+                    }
+
+                    discardScope.enterElse();
+                }
+                {
+                    if (algorithm == StepAlgorithm.VARIABLESTEP) {
+                        // Validate step
+                        JacobianVariableStepBuilder.step(ctxt, varStep, dynamicScope, builder, allFMUsSupportGetState, fmuStates, anyDiscards);
+                    }
+
+                    // Slow-down to real-time
+                    if (jacobianStepConfig.simulationProgramDelay) {
+                        RealTimeSlowDownBuilder.slowDown(ctsCtxt, dynamicScope, ctxt, builder);
+                    }
+
+                    if (everyFMUSupportsGetState) {
+                        dynamicScope.leave();
+                    }
+                }
+
+                dynamicScope.enterIf(anyDiscards.toPredicate().not());
+                {
+                    // Update currentCommunicationTime
+                    ctxt.currentCommunicationTime.setValue(ctxt.currentCommunicationTime.toMath().addition(ctxt.currentStepSize));
+
+                    ModelSwapBuilder.updateDiscardStepTime(modelSwapContext, dynamicScope, ctxt.currentStepSize);
+
+                    // Log values at current communication point
+                    dataWriterInstance.log(ctxt.currentCommunicationTime);
+                    eventUpdatingFlags = updateEventsInEventMode(builder, eventCapableInstances, fmuInstances3, dataWriterInstance, ctxt, false);
+
+
+                    ctxt.currentStepSize.setValue(calculateNextStepSize(builder, ctxt, timeBasedInputClockPorts));
+                    var checkStepSizeScope = builder.getDynamicScope().enterIf(ctxt.currentStepSize.toMath().lessEqualTo(IntExpressionValue.of(0)));
+                    var checkStepSizeScopeThen = checkStepSizeScope.enterThen();
+                    builder.getLogger().debug("Step size must be positive: %f", ctxt.currentStepSize);
+//                    checkStepSizeScopeThen.add(new AErrorStm(newAStringLiteralExp("Step size must be positive")));
+                    checkStepSizeScope.leave();
+                    builder.getLogger().debug("## Step size: %f", ctxt.currentStepSize);
+                }
+
+                scopeFmi2Api.leave();
+            }
+
+            dataWriterInstance.close();
+
+            if (settings != null) {
+                //restore previous state
+                settings.setGetDerivatives = setGetDerivativesRestore;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            errorReporter.report(0, e.toString(), null);
+            throw new ExpandException("Internal error: ", e);
+        }
+
+        return new EmptyRuntimeConfig<>();
     }
 
 

--- a/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/JacobianVariableStepBuilder.java
+++ b/plugins/jacobianstepbuilder/src/main/java/org/intocps/maestro/plugin/JacobianVariableStepBuilder.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.text.StringEscapeUtils;
 import org.intocps.maestro.ast.node.PStm;
+import org.intocps.maestro.fmi.fmi3.Fmi3ModelDescription;
+import org.intocps.maestro.fmi.fmi3.Fmi3TypeEnum;
 import org.intocps.maestro.framework.core.RelationVariable;
 import org.intocps.maestro.framework.fmi2.Fmi2SimulationEnvironment;
 import org.intocps.maestro.framework.fmi2.api.FmiBuilder;
@@ -13,7 +15,11 @@ import org.intocps.maestro.framework.fmi2.api.mabl.scoping.IfMaBlScope;
 import org.intocps.maestro.framework.fmi2.api.mabl.variables.*;
 
 import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
+import static org.intocps.maestro.framework.fmi2.api.mabl.PortFmi3Api.PortFilters.isClock;
 
 public class JacobianVariableStepBuilder {
 
@@ -95,14 +101,16 @@ public class JacobianVariableStepBuilder {
 
      static Map<InstanceVariableFmi3Api, Map<PortFmi3Api, VariableFmi2Api<Object>>> getAllInstancePortsWithOutputOrLog(Map<String, InstanceVariableFmi3Api> fmuInstances3, JacobianStepConfig jacobianStepConfig, Fmi2SimulationEnvironment env) {
 
+         Predicate<Fmi3ModelDescription.Fmi3ScalarVariable> noClocks =scalarVariable->scalarVariable.getVariable().getTypeIdentifier()!= Fmi3TypeEnum.ClockType;
+
         Map<InstanceVariableFmi3Api, Map<PortFmi3Api, VariableFmi2Api<Object>>> instancesToPortsWithValues = new HashMap<>();
         fmuInstances3.forEach((identifier, instance) -> {
-            Set<String> scalarVariablesToGet = instance.getPorts().stream()
+            Set<String> scalarVariablesToGet = instance.getPorts().stream().filter(p->isClock.negate().test(p))
                     .filter(p -> jacobianStepConfig.getVariablesOfInterest().stream()
                             .anyMatch(p1 -> p1.equals(p.getMultiModelScalarVariableName())))
                     .map(PortFmi3Api::getName).collect(Collectors.toSet());
             scalarVariablesToGet.addAll(
-                    env.getVariablesToLog(instance.getEnvironmentName()).stream().map(RelationVariable::getName)
+                    env.getVariablesToLog(instance.getEnvironmentName()).stream().filter(r->r.getFmi3ScalarVariable().filter( noClocks).isPresent()).map(RelationVariable::getName)
                             .collect(Collectors.toSet()));
 
             instancesToPortsWithValues.put(instance, instance.get(scalarVariablesToGet.toArray(String[]::new)));

--- a/pom.xml
+++ b/pom.xml
@@ -685,16 +685,16 @@
                     <value>true</value>
                 </property>
             </activation>
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://central.sonatype.com/repository/maven-snapshots</url>
-                </snapshotRepository>
-                <repository>
-                    <id>ossrh</id>
-                    <url>https://central.sonatype.com</url>
-                </repository>
-            </distributionManagement>
+<!--            <distributionManagement>-->
+<!--                <snapshotRepository>-->
+<!--                    <id>ossrh</id>-->
+<!--                    <url>https://central.sonatype.com/repository/maven-snapshots</url>-->
+<!--                </snapshotRepository>-->
+<!--                <repository>-->
+<!--                    <id>ossrh</id>-->
+<!--                    <url>https://central.sonatype.com</url>-->
+<!--                </repository>-->
+<!--            </distributionManagement>-->
 
             <build>
 

--- a/typechecker/src/main/java/org/intocps/maestro/typechecker/TypeCheckVisitor.java
+++ b/typechecker/src/main/java/org/intocps/maestro/typechecker/TypeCheckVisitor.java
@@ -607,6 +607,11 @@ class TypeCheckVisitor extends QuestionAnswerAdaptor<Context, PType> {
     }
 
     @Override
+    public PType caseADebugStm(ADebugStm node, Context question) throws AnalysisException {
+        return MableAstFactory.newAVoidType();
+    }
+
+    @Override
     public PType caseAConfigStm(AConfigStm node, Context question) throws AnalysisException {
         return MableAstFactory.newAVoidType();
     }

--- a/typechecker/src/main/resources/org/intocps/maestro/typechecker/FMI3.mabl
+++ b/typechecker/src/main/resources/org/intocps/maestro/typechecker/FMI3.mabl
@@ -190,7 +190,7 @@ module FMI3Instance
         /* end::getIntervalFraction[] */
     
         /* tag::getShiftDecimal[] */
-        int getShiftDecimal(uint valueReferences[], int nValueReferences, real shifts[]);
+        int getShiftDecimal(uint valueReferences[], int nValueReferences,out real shifts[]);
         /* end::getShiftDecimal[] */
     
         /* tag::getShiftFraction[] */

--- a/typechecker/src/main/resources/org/intocps/maestro/typechecker/FMI3.mabl
+++ b/typechecker/src/main/resources/org/intocps/maestro/typechecker/FMI3.mabl
@@ -180,8 +180,8 @@ module FMI3Instance
         /* end::setClock[] */
     
         /* tag::getIntervalDecimal[] */
-        int getIntervalDecimal(uint valueReferences[], int nValueReferences, real intervals[],
-                int qualifiers[]);
+        int getIntervalDecimal(uint valueReferences[], int nValueReferences,out real intervals[],
+               out int qualifiers[]);
         /* end::getIntervalDecimal[] */
     
         /* tag::getIntervalFraction[] */

--- a/typechecker/src/main/resources/org/intocps/maestro/typechecker/Logger.mabl
+++ b/typechecker/src/main/resources/org/intocps/maestro/typechecker/Logger.mabl
@@ -1,3 +1,5 @@
  module Logger {
     void log(int level, string message, ? values);
+
+    void logFmiCallVRefs(int level, uint vr[], uint nvr, string message, ? values);
 }


### PR DESCRIPTION
This adds the following:
* the ability to import configs with FMU3 models containing clocks
* generate a specification that handled clocks: time-base:periodic:constant,fixed interval decimal and triggered
* cleaned up the generated specs to reduce dublication
* added new debug command for context logging